### PR TITLE
MacOS with homebrew

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Homebrew default locations (both for python and z3)
+export PYTHONMODS="usr/local/lib/python2.7/site-packages:/Library/Python/2.7/site-packages:~/Library/Python/2.7/lib/python/site-packages" 
+export Z3HOME="/usr/local/Cellar/z3/4.3.1/lib/python2.7/site-packages/"
+export Z3BIN="/usr/local/Cellar/z3/4.3.1/bin"
+
+
+# Python setup
+export PYTHONPATH=$PYTHONMODS:$Z3HOME
+
+# Path setup
+export PATH=$PATH:$Z3BIN
+
+

--- a/sym_exec.py
+++ b/sym_exec.py
@@ -30,6 +30,7 @@
 
 import os
 import sys
+import platform
 import shutil
 import cPickle
 import logging
@@ -41,10 +42,6 @@ from symbolic.concolic import ConcolicEngine
 from symbolic import preprocess
 
 print "PyExZ3 (Python Symbolic Execution via Z3)"
-
-if not "PYTHONHOME" in os.environ:
-	print "Please set PYTHONHOME to the location of your python installation."
-	sys.exit(1)
 
 sys.path = [os.path.abspath(os.path.join(os.path.dirname(__file__)))] + sys.path
 usage = "usage: %prog [options] <se_descr.py path>"


### PR DESCRIPTION
MacOS setup in setup.sh.
Default locations for homebrew install of both python and z3
(brew install z3)
