### PR TITLE
Path cutting by checking for state subsumption

### DIFF
--- a/sym_exec.py
+++ b/sym_exec.py
@@ -51,6 +51,7 @@ parser.add_option("-l", "--log", dest="logfile", action="store", help="Save log 
 parser.add_option("-f", "--force", dest="force_normalize", action="store_true", help="Force the regeneration of normalized files")
 parser.add_option("-q", "--quiet", dest="quiet", action="store_true", help="Do not print statistics at the end of execution")
 parser.add_option("-s", "--single-step", dest="single_step", action="store", help="Run only one iteration and save the pickled inputs in the specified file")
+parser.add_option("-c", "--cutting", dest="cutting", action="store_true", help="Cut paths by checking for state subsumption")
 
 (options, args) = parser.parse_args()
 
@@ -87,7 +88,7 @@ preprocess.instrumentModule(app.test_name + ".py", se_instr_dir, is_app=True, in
 sys.path = [ se_instr_dir ] + sys.path
 
 stats.pushProfile("engine only")
-engine = ConcolicEngine(app.create_invocation(),app.reset_callback,options.debug)
+engine = ConcolicEngine(app.create_invocation(),app.reset_callback,options.debug,options.cutting)
 if options.single_step:
 	return_vals = engine.run(1)
 	inputs = engine.generateAllInputs()

--- a/symbolic/concolic.py
+++ b/symbolic/concolic.py
@@ -39,7 +39,7 @@ log = logging.getLogger("se.conc")
 stats = getStats()
 
 class ConcolicEngine:
-	def __init__(self, funcinv, reset, debug):
+	def __init__(self, funcinv, reset, debug, cutting):
 		self.invocation = funcinv
 		self.reset_func = reset
 		self.constraints_to_solve = deque([])
@@ -53,8 +53,10 @@ class ConcolicEngine:
 		# self.path.setTracer(self.tracer)
 		stats.newCounter("explored paths")
 		self.generated_inputs = []
+		self.cutting = cutting
 		self.states = defaultdict(list) # used for state matching
-		stats.newCounter("paths cut")
+		if cutting:
+			stats.newCounter("paths cut")
 
 	def addConstraint(self, constraint):
 		self.constraints_to_solve.append(constraint)

--- a/symbolic/constraint.py
+++ b/symbolic/constraint.py
@@ -52,15 +52,11 @@ class Constraint:
 		else:
 			return False
 
-	def processConstraint(self):
-		# We want to mark this as processed even in case of error
-		# so it is best to do it at the beginning
-		self.processed = True
+	def buildZ3Asserts(self):
 		res = False
 		sym_asserts = []
 		sym_vars = {}
-
-		tmp = self.parent
+		tmp = self
 		while tmp.predicate is not None:
 			p = tmp.predicate
 			(ret, expr) = p.buildZ3Expr()
@@ -70,6 +66,14 @@ class Constraint:
 				for v in p.sym_vars:
 					sym_vars[v] = p.sym_vars[v]
 			tmp = tmp.parent
+		return (res, sym_asserts, sym_vars)
+
+	def processConstraint(self):
+		# We want to mark this as processed even in case of error
+		# so it is best to do it at the beginning
+		self.processed = True
+
+		(res, sym_asserts, sym_vars) = self.parent.buildZ3Asserts()
 
 		(ret, expr) = self.predicate.buildZ3Expr()
 		if expr is None:

--- a/symbolic/path_to_constraint.py
+++ b/symbolic/path_to_constraint.py
@@ -29,13 +29,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-from symbolic_types import SymbolicType
+import symbolic.z3_wrap as z3_wrap
+from symbolic_types import SymbolicType, SymbolicInteger
 from predicate import Predicate
 from constraint import Constraint
 import logging
+from stats import getStats
 import utils
+import inspect
+import copy
+from z3 import *
+
+class EndExecutionThrowable: pass
 
 log = logging.getLogger("se.pathconstraint")
+stats = getStats()
 
 class PathToConstraint:
 	def __init__(self, engine):
@@ -44,9 +52,11 @@ class PathToConstraint:
 		self.engine = engine
 		self.root_constraint = Constraint(None, None)
 		self.current_constraint = self.root_constraint
+		self.target_reached = False
 
 	def reset(self):
 		self.current_constraint = self.root_constraint
+		self.target_reached = False
 
 	def whichBranch(self, branch, cond_expr):
 		""" To be called from the process being executed, this function acts as instrumentation.
@@ -55,6 +65,12 @@ class PathToConstraint:
 
 		if not (isinstance(cond_expr,SymbolicType)):
 			return
+
+		stats.pushProfile("subsumption checking")
+		# Important: this call may jump out of this function (and the
+		# whole execution) by throwing an EndExecutionThrowable
+		self.tryCut()
+		stats.popProfile()
 
 		# add both possible predicate outcomes to constraint (tree)
 		p = Predicate(cond_expr, branch)
@@ -77,3 +93,58 @@ class PathToConstraint:
 			log.debug("Processed constraint: %s" % c)
 
 		self.current_constraint = c
+
+		if not self.engine.selected or self.engine.selected is cneg:
+			self.target_reached = True
+
+	def tryCut(self):
+		if not self.target_reached:
+			return
+
+		(frame, filename, line_number, function_name, lines, line_index) = inspect.getouterframes(
+			inspect.currentframe())[3]
+		pc = filename + ":" + str(line_number)
+
+		state = dict(frame.f_locals)
+		state.pop("__se_cond__", None) # remove __se_cond__ because  it is never reused
+
+		# check for subsumption
+		for (old_state, old_constraint) in self.engine.states[pc]:
+			if self.isSubsumed(state, old_state, old_constraint):
+				log.debug("State subsumed: %s contained in %s" % (self.current_constraint, old_constraint))
+				stats.incCounter("paths cut")
+				raise EndExecutionThrowable()
+
+		# was not subsumed by anything, record state
+		self.engine.states[pc].append((state, self.current_constraint))
+
+	def isSubsumed(self, my_state, old_state, old_constraint):
+		if not set(my_state) == set(old_state):
+			return
+
+		my_concretes = {k: v for k, v in my_state.iteritems() if not isinstance(v, SymbolicType)}
+		old_concretes = {k: v for k, v in old_state.iteritems() if not isinstance(v, SymbolicType)}
+		# all purely concrete variables must be equal
+		for var in my_concretes.viewkeys() & old_concretes.viewkeys():
+			if my_concretes[var] != old_concretes[var]:
+				return
+
+		# assert that the states must be equal
+		my_constraint = self.current_constraint
+		state_vars = set()
+		for var in set(my_state):
+			# use a variable name that is illegal in python
+			state_var = var + "$"
+			state_sym_var = SymbolicInteger(state_var, 32)
+			state_vars.add(state_var)
+			my_p = Predicate(state_sym_var == my_state[var], True)
+			my_constraint = Constraint(my_constraint, my_p)
+			old_p = Predicate(state_sym_var == old_state[var], True)
+			old_constraint = Constraint(old_constraint, old_p)
+
+		(_, my_asserts, _) = my_constraint.buildZ3Asserts()
+		(_, old_asserts, old_sym_vars) = old_constraint.buildZ3Asserts()
+		old_inputs = [v[1] for k, v in old_sym_vars.iteritems() if not k in state_vars]
+
+		subsumed = Implies(And(my_asserts), Exists(old_inputs, And(old_asserts)))
+		return z3_wrap.findCounterexample([], subsumed, []) == None

--- a/symbolic/path_to_constraint.py
+++ b/symbolic/path_to_constraint.py
@@ -66,11 +66,12 @@ class PathToConstraint:
 		if not (isinstance(cond_expr,SymbolicType)):
 			return
 
-		stats.pushProfile("subsumption checking")
-		# Important: this call may jump out of this function (and the
-		# whole execution) by throwing an EndExecutionThrowable
-		self.tryCut()
-		stats.popProfile()
+		if self.engine.cutting:
+			stats.pushProfile("subsumption checking")
+			# Important: this call may jump out of this function (and the
+			# whole execution) by throwing an EndExecutionThrowable
+			self.tryCut()
+			stats.popProfile()
 
 		# add both possible predicate outcomes to constraint (tree)
 		p = Predicate(cond_expr, branch)

--- a/symbolic/path_to_constraint.py
+++ b/symbolic/path_to_constraint.py
@@ -102,6 +102,14 @@ class PathToConstraint:
 		if not self.target_reached:
 			return
 
+		# Check that this whichBranch call was made from the top level function in the program
+		# under test.
+		# TODO: add recording of state from multiple function frames to remove this limitation
+		caller_of_instrumented = inspect.getouterframes(inspect.currentframe())[4][3] # function name
+		if not caller_of_instrumented == "execute":
+			log.debug("Skip subsumption checking due to not being in top level function")
+			return
+
 		(frame, filename, line_number, function_name, lines, line_index) = inspect.getouterframes(
 			inspect.currentframe())[3]
 		pc = filename + ":" + str(line_number)

--- a/test/cut_diamond.py
+++ b/test/cut_diamond.py
@@ -1,6 +1,8 @@
 # Modification of diamond.py, which cleans up state by deleting variables that
 # are no longer used. This allows for state subsumption checking to succeed.
 
+# This test should fail with --cutting
+
 def cut_diamond(a,b,c):
 	ret = 0
 	if (a):
@@ -15,4 +17,4 @@ def cut_diamond(a,b,c):
 	return ret
 
 def expected_result():
-	return [ 0, 1, 1, 2, 2, 3]
+	return [ 0, 1, 1, 1, 2, 2, 2, 3]

--- a/test/cut_diamond.py
+++ b/test/cut_diamond.py
@@ -1,0 +1,18 @@
+# Modification of diamond.py, which cleans up state by deleting variables that
+# are no longer used. This allows for state subsumption checking to succeed.
+
+def cut_diamond(a,b,c):
+	ret = 0
+	if (a):
+		ret = ret + 1
+	del a
+	if (b):
+		ret = ret + 1
+	del b
+	if (c):
+		ret = ret + 1
+	del c
+	return ret
+
+def expected_result():
+	return [ 0, 1, 1, 2, 2, 3]


### PR DESCRIPTION
I've implemented cutting paths when it is detected that a state is subsumed by one already visited on another path. Whenever the same control location is reached again, it is checked whether the new state is included in an old one.

The check is done with a call to Z3. The solving times can sometimes be quite large (probably due to the forall quantification). This can be seen in a variation of the `diamonds.py` test with one more diamond.

The feature is off by default and can be enabled with `--cutting`

This feature is quite experimental, so including it in the main line might not be the best choice.