### PR TITLE
run_tests uses subprocess to avoid os.system related bugs

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import subprocess
 from optparse import OptionParser
 from sys import platform as _platform
 
@@ -34,8 +35,9 @@ files = [ f for f in os.listdir(test_dir) if re.search(".py$",f) ]
 failed = []
 for f in files:
 	# execute the python runner for this test
-        full = test_dir + os.sep + f
-        ret = os.system(sys.executable + " sym_exec.py --m=25 " + full +" > out")
+        full = os.path.join(test_dir, f)
+        with open(os.devnull, 'w') as devnull:
+            ret = subprocess.call([sys.executable, "sym_exec.py", "--m=25", full], stdout=devnull)
         if (ret == 0):
             myprint(bcolors.SUCCESS, "✓", "Test " + f + " passed.")
         else:


### PR DESCRIPTION
run_tests now leverages the subprocess module for more robust calls to the symbolic execution engine. For example, the previous code snippet would not encapsulate paths that contained a space, failing to run the tests.

Additionally, an out file is no longer written. It is unclear if that was on purpose but given that execution of tests continues until competition most of the outputs are quickly overwritten.
