### PR TITLE
Z3 Wrapper Debug Logging Output

### DIFF
--- a/symbolic/z3_wrap.py
+++ b/symbolic/z3_wrap.py
@@ -2,10 +2,13 @@
 
 import sys
 import ast
+import logging
 
 from z3 import *
 from .z3_expr.integer import Z3Integer
 from .z3_expr.bitvector import Z3BitVector
+
+log = logging.getLogger("se.z3")
 
 class Z3Wrapper(object):
 	def __init__(self):
@@ -22,15 +25,10 @@ class Z3Wrapper(object):
 		self.query = query
 		self.asserts = self._coneOfInfluence(asserts,query)
 		res = self._findModel()
-		if (False):
-			print("-- Query")
-			print(self.query)
-			print("-- Asserts")
-			print(asserts)
-			print("-- Cone")
-			print(self.asserts)
-			print("-- Result")
-			print(res)
+		log.debug("Query -- %s" % self.query)
+		log.debug("Asserts -- %s" % asserts)
+		log.debug("Cone -- %s" % self.asserts)
+		log.debug("Result -- %s" % res)
 		return res
 
 	# private


### PR DESCRIPTION
Originally the z3_wrap.py debugging output would go to standard out
through print statements guarded by a constant conditional statement.

I've replaced the print statements with DEBUG logging statements.
