### PR TITLE
CVC Import Conditioned on Solver Flag

### DIFF
--- a/symbolic/explore.py
+++ b/symbolic/explore.py
@@ -5,7 +5,6 @@ import logging
 import os
 
 from .z3_wrap import Z3Wrapper
-from .cvc_wrap import CVCWrapper
 from .path_to_constraint import PathToConstraint
 from .invocation import FunctionInvocation
 from .symbolic_types import symbolic_type, SymbolicType
@@ -31,6 +30,7 @@ class ExplorationEngine:
 		if solver == "z3":
 			self.solver = Z3Wrapper()
 		elif solver == "cvc":
+			from .cvc_wrap import CVCWrapper
 			self.solver = CVCWrapper()
 		else:
 			raise Exception("Unknown solver %s" % solver)


### PR DESCRIPTION
CVC is only imported if it is the selected solver. This allows users to use PyExZ3 without having CVC installed. I believe this fixes the issue we discussed on https://github.com/thomasjball/PyExZ3/pull/11.

To help prevent situations like this in the future I'm going to incorporate a Windows-based Z3-only environment in my test process. Please let me know if you see any other issues or incompatibilities.
