### PR TITLE
Fix for Symbolic Dict to Boolean Infinite Recursion

### DIFF
--- a/fail/dictbool.py
+++ b/fail/dictbool.py
@@ -1,0 +1,12 @@
+from symbolic.args import *
+
+@symbolic(d={})
+def dictbool(d):
+    x = d or {}
+    if x == {}:
+        return 0
+    return 1
+
+def expected_result():
+	return [0, 1]
+    

--- a/symbolic/symbolic_types/symbolic_dict.py
+++ b/symbolic/symbolic_types/symbolic_dict.py
@@ -19,9 +19,11 @@ class SymbolicDict(SymbolicObject,dict):
 		SymbolicObject.__init__(self,name,None)
 		dict.__init__(self,kwargs)
 
-
 	def getConcrValue(self):
 		return self
+		
+	def __bool__(self):
+		return bool(len(self))
 
 #	def wrap(conc,sym):
 #		pass # TODO


### PR DESCRIPTION
If `__bool__` is called (through the bool constructor) on a SymbolicDict, the `__bool__` of SymbolicObject is called, which calls `__bool__` on the concrete value of the SymbolicDict, which is the SymbolicDict. This circular recursion continues until the maximum recursion depth is hit and PyEx terminates. `fail/dictbool.py` gives a test case which demonstrates this failure.

As a temporary fix until the SymbolicDict functionality is fleshed out, `__bool__` is implemented in SymbolicDict to call `__len__` which should match the functionality of a normal dict.