### PR TITLE
CVC Support for Strings as Effective Booleans

### DIFF
--- a/fail/effectivebool.py
+++ b/fail/effectivebool.py
@@ -1,0 +1,14 @@
+from symbolic.args import *
+
+@symbolic(s="foo", x=1)
+def effectivebool(s, x):
+	if s:
+		return 0
+	elif x:
+		return 1
+	else:
+	    return 2
+
+def expected_result():
+	return [0,1,2]
+    

--- a/fail/effectivebool.py
+++ b/fail/effectivebool.py
@@ -1,14 +1,17 @@
+"""Tests strings and integers used as a branch condition. The
+interpreter calls the bool constructor with the contents of the branch
+condition passed in as the argument. If a __bool__ function does not
+exist, __len__ is called and compared to zero."""
 from symbolic.args import *
 
-@symbolic(s="foo", x=1)
-def effectivebool(s, x):
-	if s:
-		return 0
-	elif x:
-		return 1
-	else:
-	    return 2
+@symbolic(string="foo", num=1)
+def effectivebool(string, num):
+    if string:
+        return 0
+    elif num:
+        return 1
+    else:
+        return 2
 
 def expected_result():
-	return [0,1,2]
-    
+    return [0, 1, 2]

--- a/symbolic/cvc_expr/exprbuilder.py
+++ b/symbolic/cvc_expr/exprbuilder.py
@@ -59,7 +59,8 @@ class ExprBuilder(object):
         if isinstance(expr, list):
             op = expr[0]
             args = [self._astToCVCExpr(a, env) for a in expr[1:]]
-            cvc_l, cvc_r = args[0], args[1]
+            cvc_l = args[0]
+            cvc_r = args[1] if len(args) > 1 else None
             log.debug("Building %s %s %s" % (cvc_l, op, cvc_r))
 
             # arithmetical operations
@@ -85,6 +86,10 @@ class ExprBuilder(object):
                 return cvc_l | cvc_l
             elif op == "&":
                 return cvc_l & cvc_r
+                
+            # string
+            elif op == "str.len":
+                return cvc_l.len()
 
             # equality gets coerced to integer
             elif op == "==":

--- a/symbolic/cvc_expr/exprbuilder.py
+++ b/symbolic/cvc_expr/exprbuilder.py
@@ -86,7 +86,7 @@ class ExprBuilder(object):
                 return cvc_l | cvc_l
             elif op == "&":
                 return cvc_l & cvc_r
-                
+
             # string
             elif op == "str.len":
                 return cvc_l.len()

--- a/symbolic/cvc_expr/string.py
+++ b/symbolic/cvc_expr/string.py
@@ -3,6 +3,7 @@ import logging
 import CVC4
 
 from .expression import CVCExpression
+from .integer import CVCInteger
 
 log = logging.getLogger("se.cvc.string")
 
@@ -22,3 +23,6 @@ class CVCString(CVCExpression):
     def getvalue(self):
         ce = self.solver.getValue(self.cvc_expr)
         return ce.getConstString().toString()
+
+    def len(self):
+        return CVCInteger(self.em.mkExpr(CVC4.STRING_LENGTH, self.cvc_expr), self.solver)

--- a/symbolic/cvc_expr/string.py
+++ b/symbolic/cvc_expr/string.py
@@ -22,8 +22,3 @@ class CVCString(CVCExpression):
     def getvalue(self):
         ce = self.solver.getValue(self.cvc_expr)
         return ce.getConstString().toString()
-
-    def effectivebool(self):
-        strlen = self.em.mkExpr(CVC4.STRING_LENGTH, self.cvc_expr)
-        zero = self.em.mkConst(Rational(Integer(str(0))))
-        return CVCExpression(self.em.mkExpr(CVC4.EQUAL, strlen.cvc_expr, zero), self.solver)

--- a/symbolic/cvc_expr/string.py
+++ b/symbolic/cvc_expr/string.py
@@ -22,3 +22,8 @@ class CVCString(CVCExpression):
     def getvalue(self):
         ce = self.solver.getValue(self.cvc_expr)
         return ce.getConstString().toString()
+
+    def effectivebool(self):
+        strlen = self.em.mkExpr(CVC4.STRING_LENGTH, self.cvc_expr)
+        zero = self.em.mkConst(Rational(Integer(str(0))))
+        return CVCExpression(self.em.mkExpr(CVC4.EQUAL, strlen.cvc_expr, zero), self.solver)

--- a/symbolic/symbolic_types/symbolic_str.py
+++ b/symbolic/symbolic_types/symbolic_str.py
@@ -1,4 +1,5 @@
 from . symbolic_type import SymbolicObject
+from symbolic.symbolic_types.symbolic_int import SymbolicInteger
 
 class SymbolicStr(SymbolicObject, str):
 
@@ -20,6 +21,13 @@ class SymbolicStr(SymbolicObject, str):
 
 	def _op_worker(self, args, fun, op):
 		return self._do_sexpr(args, fun, op, SymbolicStr.wrap)
+	
+	def __bool__(self):
+	    return SymbolicObject.__bool__(self.__len__() != 0)
+	
+	def __len__(self):
+		return self._do_sexpr([self], lambda x: len(x), "str.len", SymbolicInteger.wrap)
+
 
 # Currently no String operations are supported.
 ops =  []

--- a/symbolic/symbolic_types/symbolic_str.py
+++ b/symbolic/symbolic_types/symbolic_str.py
@@ -26,7 +26,7 @@ class SymbolicStr(SymbolicObject, str):
 	    return SymbolicObject.__bool__(self.__len__() != 0)
 
 	def __len__(self):
-		return self._do_sexpr([self], len,
+		return self._do_sexpr([self], lambda x: len(x),
 		                        "str.len", SymbolicInteger.wrap)
 
 

--- a/symbolic/symbolic_types/symbolic_str.py
+++ b/symbolic/symbolic_types/symbolic_str.py
@@ -21,12 +21,13 @@ class SymbolicStr(SymbolicObject, str):
 
 	def _op_worker(self, args, fun, op):
 		return self._do_sexpr(args, fun, op, SymbolicStr.wrap)
-	
+
 	def __bool__(self):
 	    return SymbolicObject.__bool__(self.__len__() != 0)
-	
+
 	def __len__(self):
-		return self._do_sexpr([self], lambda x: len(x), "str.len", SymbolicInteger.wrap)
+		return self._do_sexpr([self], len,
+		                        "str.len", SymbolicInteger.wrap)
 
 
 # Currently no String operations are supported.


### PR DESCRIPTION
I've implemented `__bool__` and `__len__` in `SymbolicStr` to support correct constraint generation when strings are used as branch conditions. `SymbolicStr` adds the unary `str.len` operator to the AST, wrapped in a `SymbolicInteger`. Currently `fail/effectivebool.py` will only pass when using the `--cvc` flag.