### PR TITLE
Overriding len Built-In

### DIFF
--- a/symbolic/loader.py
+++ b/symbolic/loader.py
@@ -7,6 +7,11 @@ import sys
 from .invocation import FunctionInvocation
 from .symbolic_types import SymbolicInteger, getSymbolic
 
+# The built-in definition of len wraps the return value in an int() constructor, destroying any symbolic types.
+# By redefining len here we can preserve symbolic integer types.
+import builtins
+builtins.len = (lambda x : x.__len__())
+
 class Loader:
 	def __init__(self, filename, entry):
 		self._fileName = os.path.basename(filename)

--- a/test/len_test.py
+++ b/test/len_test.py
@@ -1,0 +1,20 @@
+from symbolic.args import *
+
+class Foo():
+    def __init__(self, var):
+        self.var = var
+
+    def __len__(self):
+        return self.var
+
+@symbolic(a=0)
+def len_test(a):
+    f = Foo(a)
+    if len(f) == 2:
+        return 1
+    else:
+        return 0
+
+def expected_result():
+    return [0, 1]
+


### PR DESCRIPTION
I recently discovered that the built-in `len` operator is basically implemented as so:

```len = lambda x : int(x.__len__())```

This replaces any symbolic integers from `__len__` with plain integers. I have a working fix that overrides the built-in by removing the `int` wrapper. Is this too much of a hack? In principle it could break code that relies on this conversion, but Pythonic code generally doesn't bother with the particular types of things as long as they act as expected.

Also, I didn't know the best place to put the override. I put it at the top of the `loader` module lacking a better idea.