### PR TITLE
PEP8 and Code Cleanup

### DIFF
--- a/pyexz3.py
+++ b/pyexz3.py
@@ -1,9 +1,6 @@
 # Copyright: see copyright.txt
 
-import os
-import sys
 import logging
-import traceback
 from optparse import OptionParser
 
 from symbolic.loader import *
@@ -19,49 +16,50 @@ parser = OptionParser(usage=usage)
 parser.add_option("-l", "--log", dest="logfile", action="store", help="Save log output to a file", default="")
 parser.add_option("-s", "--start", dest="entry", action="store", help="Specify entry point", default="")
 parser.add_option("-g", "--graph", dest="dot_graph", action="store_true", help="Generate a DOT graph of execution tree")
-parser.add_option("-m", "--max-iters", dest="max_iters", type="int", help="Run specified number of iterations", default=0)
+parser.add_option("-m", "--max-iters", dest="max_iters", type="int", help="Run specified number of iterations",
+                  default=0)
 parser.add_option("--cvc", dest="cvc", action="store_true", help="Use the CVC SMT solver instead of Z3", default=False)
 parser.add_option("--z3", dest="cvc", action="store_false", help="Use the Z3 SMT solver")
 
 (options, args) = parser.parse_args()
 
 if not (options.logfile == ""):
-	logging.basicConfig(filename=options.logfile,level=logging.DEBUG)
+    logging.basicConfig(filename=options.logfile, level=logging.DEBUG)
 
 if len(args) == 0 or not os.path.exists(args[0]):
-	parser.error("Missing app to execute")
-	sys.exit(1)
+    parser.error("Missing app to execute")
+    sys.exit(1)
 
 solver = "cvc" if options.cvc else "z3"
 
 filename = os.path.abspath(args[0])
-	
-# Get the object describing the application
-app = loaderFactory(filename,options.entry)
-if app == None:
-	sys.exit(1)
 
-print ("Exploring " + app.getFile() + "." + app.getEntry())
+# Get the object describing the application
+app = loaderFactory(filename, options.entry)
+if app is None:
+    sys.exit(1)
+
+print("Exploring " + app.getFile() + "." + app.getEntry())
 
 result = None
 try:
-	engine = ExplorationEngine(app.createInvocation(), solver=solver)
-	generatedInputs, returnVals, path = engine.explore(options.max_iters)
-	# check the result
-	result = app.executionComplete(returnVals)
+    engine = ExplorationEngine(app.createInvocation(), solver=solver)
+    generatedInputs, returnVals, path = engine.explore(options.max_iters)
+    # check the result
+    result = app.executionComplete(returnVals)
 
-	# output DOT graph
-	if (options.dot_graph):
-		file = open(filename+".dot","w")
-		file.write(path.toDot())	
-		file.close()
+    # output DOT graph
+    if options.dot_graph:
+        file = open(filename + ".dot", "w")
+        file.write(path.toDot())
+        file.close()
 
 except ImportError as e:
-	# createInvocation can raise this
-	logging.error(e)
-	sys.exit(1)
+    # createInvocation can raise this
+    logging.error(e)
+    sys.exit(1)
 
-if result == None or result == True:
-	sys.exit(0);
+if result is None or result:
+    sys.exit(0)
 else:
-	sys.exit(1);	
+    sys.exit(1)

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,17 +5,20 @@ import subprocess
 from optparse import OptionParser
 from sys import platform as _platform
 
+
 class bcolors:
     SUCCESS = '\033[32m'
     WARNING = '\033[33m'
     FAIL = '\033[31m'
     ENDC = '\033[0m'
 
-def myprint(color, s, *args):
-  if _platform != "win32" and sys.stdout.isatty():
-    print(color, s, bcolors.ENDC, *args)
-  else:
-    print(*args)
+
+def myprint(color, s, *printargs):
+    if _platform != "win32" and sys.stdout.isatty():
+        print(color, s, bcolors.ENDC, *printargs)
+    else:
+        print(*printargs)
+
 
 usage = "usage: %prog [options] <test directory>"
 parser = OptionParser()
@@ -26,31 +29,31 @@ parser.add_option("--z3", dest="cvc", action="store_false", help="Use the Z3 SMT
 if len(args) == 0 or not os.path.exists(args[0]):
     parser.error("Please supply directory of tests")
     sys.exit(1)
-    
+
 test_dir = os.path.abspath(args[0])
 
 if not os.path.isdir(test_dir):
     print("Please provide a directory of test scripts.")
     sys.exit(1)
 
-files = [ f for f in os.listdir(test_dir) if re.search(".py$",f) ]
+files = [f for f in os.listdir(test_dir) if re.search(".py$", f)]
 
 failed = []
 for f in files:
-	# execute the python runner for this test
-        full = os.path.join(test_dir, f)
-        with open(os.devnull, 'w') as devnull:
-            solver = "--cvc" if options.cvc else "--z3"
-            ret = subprocess.call([sys.executable, "pyexz3.py", "--m=25", solver, full], stdout=devnull)
-        if (ret == 0):
-            myprint(bcolors.SUCCESS, "✓", "Test " + f + " passed.")
-        else:
-            failed.append(f)
-            myprint(bcolors.FAIL, "✗", "Test " + f + " failed.")
+    # execute the python runner for this test
+    full = os.path.join(test_dir, f)
+    with open(os.devnull, 'w') as devnull:
+        solver = "--cvc" if options.cvc else "--z3"
+        ret = subprocess.call([sys.executable, "pyexz3.py", "--m=25", solver, full], stdout=devnull)
+    if ret == 0:
+        myprint(bcolors.SUCCESS, "✓", "Test " + f + " passed.")
+    else:
+        failed.append(f)
+        myprint(bcolors.FAIL, "✗", "Test " + f + " failed.")
 
-if failed != []:
-	print("RUN FAILED")
-	print(failed)
-	sys.exit(1)
+if len(failed) > 0:
+    print("RUN FAILED")
+    print(failed)
+    sys.exit(1)
 else:
-	sys.exit(0)
+    sys.exit(0)

--- a/symbolic/args.py
+++ b/symbolic/args.py
@@ -1,11 +1,14 @@
 def symbolic(**arg_types):
-	def decorator(f):
-		f.symbolic_args = arg_types
-		return f
-	return decorator
+    def decorator(f):
+        f.symbolic_args = arg_types
+        return f
+
+    return decorator
+
 
 def concrete(**arg_types):
-	def decorator(f):
-		f.concrete_args = arg_types
-		return f
-	return decorator
+    def decorator(f):
+        f.concrete_args = arg_types
+        return f
+
+    return decorator

--- a/symbolic/constraint.py
+++ b/symbolic/constraint.py
@@ -4,63 +4,64 @@ import logging
 
 log = logging.getLogger("se.constraint")
 
+
 class Constraint:
-	cnt = 0
-	"""A constraint is a list of predicates leading to some specific
-	   position in the code."""
-	def __init__(self, parent, last_predicate):
-		self.inputs = None
-		self.predicate = last_predicate
-		self.processed = False
-		self.parent = parent
-		self.children = []
-		self.id = self.__class__.cnt
-		self.__class__.cnt += 1
+    cnt = 0
+    """A constraint is a list of predicates leading to some specific
+       position in the code."""
 
-	def __eq__(self, other):
-		"""Two Constraints are equal iff they have the same chain of predicates"""
-		if isinstance(other, Constraint):
-			if not self.predicate == other.predicate:
-				return False
-			return self.parent is other.parent
-		else:
-			return False
+    def __init__(self, parent, last_predicate):
+        self.inputs = None
+        self.predicate = last_predicate
+        self.processed = False
+        self.parent = parent
+        self.children = []
+        self.id = self.__class__.cnt
+        self.__class__.cnt += 1
 
-	def getAssertsAndQuery(self):
-		self.processed = True
+    def __eq__(self, other):
+        """Two Constraints are equal iff they have the same chain of predicates"""
+        if isinstance(other, Constraint):
+            if not self.predicate == other.predicate:
+                return False
+            return self.parent is other.parent
+        else:
+            return False
 
-		# collect the assertions
-		asserts = []
-		tmp = self.parent
-		while tmp.predicate is not None:
-			asserts.append(tmp.predicate)
-			tmp = tmp.parent
+    def getAssertsAndQuery(self):
+        self.processed = True
 
-		return asserts, self.predicate	       
+        # collect the assertions
+        asserts = []
+        tmp = self.parent
+        while tmp.predicate is not None:
+            asserts.append(tmp.predicate)
+            tmp = tmp.parent
 
-	def getLength(self):
-		if self.parent == None:
-			return 0
-		return 1 + self.parent.getLength()
+        return asserts, self.predicate
 
-	def __str__(self):
-		return str(self.predicate) + "  (processed: %s, path_len: %d)" % (self.processed,self.getLength())
+    def getLength(self):
+        if self.parent is None:
+            return 0
+        return 1 + self.parent.getLength()
 
-	def __repr__(self):
-		s = repr(self.predicate) + " (processed: %s)" % (self.processed)
-		if self.parent is not None:
-			s += "\n  path: %s" % repr(self.parent)
-		return s
+    def __str__(self):
+        return str(self.predicate) + "  (processed: %s, path_len: %d)" % (self.processed, self.getLength())
 
-	def findChild(self, predicate):
-		for c in self.children:
-			if predicate == c.predicate:
-				return c
-		return None
+    def __repr__(self):
+        s = repr(self.predicate) + " (processed: %s)" % self.processed
+        if self.parent is not None:
+            s += "\n  path: %s" % repr(self.parent)
+        return s
 
-	def addChild(self, predicate):
-		assert(self.findChild(predicate) is None)
-		c = Constraint(self, predicate)
-		self.children.append(c)
-		return c
+    def findChild(self, predicate):
+        for c in self.children:
+            if predicate == c.predicate:
+                return c
+        return None
 
+    def addChild(self, predicate):
+        assert (self.findChild(predicate) is None)
+        c = Constraint(self, predicate)
+        self.children.append(c)
+        return c

--- a/symbolic/cvc_expr/exprbuilder.py
+++ b/symbolic/cvc_expr/exprbuilder.py
@@ -29,6 +29,7 @@ class ExprBuilder(object):
         sym_expr = self._astToCVCExpr(pred.symtype, env)
         if env is None:
             if not sym_expr.cvc_expr.getType().isBoolean():
+                # noinspection PyUnresolvedReferences
                 sym_expr = (sym_expr == CVCInteger.constant(0, self.solver)).not_op()
             if not pred.result:
                 sym_expr = sym_expr.not_op()
@@ -150,4 +151,3 @@ class ExprBuilder(object):
             return None
         else:
             utils.crash("Unknown node during conversion from ast to CVC (expressions): %s" % expr)
-    

--- a/symbolic/cvc_expr/exprbuilder.py
+++ b/symbolic/cvc_expr/exprbuilder.py
@@ -29,7 +29,6 @@ class ExprBuilder(object):
         sym_expr = self._astToCVCExpr(pred.symtype, env)
         if env is None:
             if not sym_expr.cvc_expr.getType().isBoolean():
-                # noinspection PyUnresolvedReferences
                 sym_expr = (sym_expr == CVCInteger.constant(0, self.solver)).not_op()
             if not pred.result:
                 sym_expr = sym_expr.not_op()

--- a/symbolic/cvc_expr/expression.py
+++ b/symbolic/cvc_expr/expression.py
@@ -2,7 +2,6 @@ import logging
 
 import CVC4
 
-
 log = logging.getLogger("se.cvc_expr.expr")
 
 

--- a/symbolic/cvc_expr/string.py
+++ b/symbolic/cvc_expr/string.py
@@ -40,11 +40,11 @@ class CVCString(CVCExpression):
 
     def __add__(self, other):
         return CVCString(self.em.mkExpr(CVC4.STRING_CONCAT,
-            self.cvc_expr, other.cvc_expr), self.solver)
+                                        self.cvc_expr, other.cvc_expr), self.solver)
 
     def __contains__(self, item):
         return CVCExpression(self.em.mkExpr(CVC4.STRING_STRCTN,
-            self.cvc_expr, item.cvc_expr), self.solver)
+                                            self.cvc_expr, item.cvc_expr), self.solver)
 
     def __getitem__(self, item):
         if isinstance(item, slice):
@@ -59,6 +59,7 @@ class CVCString(CVCExpression):
             # solution space is a significant undertaking.
             self.solver.guards.append(self.len() > item.start)
             self.solver.guards.append(self.len() >= item.stop)
+            # noinspection PyUnresolvedReferences
             return CVCString(self.em.mkExpr(CVC4.STRING_SUBSTR, self.cvc_expr,
                                             item.start.cvc_expr, offset.cvc_expr),
                              self.solver)

--- a/symbolic/cvc_expr/string.py
+++ b/symbolic/cvc_expr/string.py
@@ -59,7 +59,6 @@ class CVCString(CVCExpression):
             # solution space is a significant undertaking.
             self.solver.guards.append(self.len() > item.start)
             self.solver.guards.append(self.len() >= item.stop)
-            # noinspection PyUnresolvedReferences
             return CVCString(self.em.mkExpr(CVC4.STRING_SUBSTR, self.cvc_expr,
                                             item.start.cvc_expr, offset.cvc_expr),
                              self.solver)

--- a/symbolic/cvc_wrap.py
+++ b/symbolic/cvc_wrap.py
@@ -1,8 +1,5 @@
 import logging
 
-import utils
-
-import CVC4
 from CVC4 import ExprManager, SmtEngine, SExpr
 
 from symbolic.cvc_expr.exprbuilder import ExprBuilder

--- a/symbolic/cvc_wrap.py
+++ b/symbolic/cvc_wrap.py
@@ -14,7 +14,7 @@ class CVCWrapper(object):
                # Enable modular arithmetic with constant modulus
                'rewrite-divk': 'true',
                # Per Query timeout of 5 seconds
-               'tlimit-per': 5000,
+               'tlimit-per': 10000,
                'output-language': 'smt2',
                'input-language': 'smt2'}
     logic = 'ALL_SUPPORTED'

--- a/symbolic/explore.py
+++ b/symbolic/explore.py
@@ -2,119 +2,118 @@
 
 from collections import deque
 import logging
-import os
 
 from .z3_wrap import Z3Wrapper
 from .path_to_constraint import PathToConstraint
-from .invocation import FunctionInvocation
 from .symbolic_types import symbolic_type, SymbolicType
 
 log = logging.getLogger("se.conc")
 
+
 class ExplorationEngine:
-	def __init__(self, funcinv, solver="z3"):
-		self.invocation = funcinv
-		# the input to the function
-		self.symbolic_inputs = {}  # string -> SymbolicType
-		# initialize
-		for n in funcinv.getNames():
-			self.symbolic_inputs[n] = funcinv.createArgumentValue(n)
+    def __init__(self, funcinv, solver="z3"):
+        self.invocation = funcinv
+        # the input to the function
+        self.symbolic_inputs = {}  # string -> SymbolicType
+        # initialize
+        for n in funcinv.getNames():
+            self.symbolic_inputs[n] = funcinv.createArgumentValue(n)
 
-		self.constraints_to_solve = deque([])
-		self.num_processed_constraints = 0
+        self.constraints_to_solve = deque([])
+        self.num_processed_constraints = 0
 
-		self.path = PathToConstraint(lambda c : self.addConstraint(c))
-		# link up SymbolicObject to PathToConstraint in order to intercept control-flow
-		symbolic_type.SymbolicObject.SI = self.path
+        self.path = PathToConstraint(lambda c: self.addConstraint(c))
+        # link up SymbolicObject to PathToConstraint in order to intercept control-flow
+        symbolic_type.SymbolicObject.SI = self.path
 
-		if solver == "z3":
-			self.solver = Z3Wrapper()
-		elif solver == "cvc":
-			from .cvc_wrap import CVCWrapper
-			self.solver = CVCWrapper()
-		else:
-			raise Exception("Unknown solver %s" % solver)
+        if solver == "z3":
+            self.solver = Z3Wrapper()
+        elif solver == "cvc":
+            from .cvc_wrap import CVCWrapper
+            self.solver = CVCWrapper()
+        else:
+            raise Exception("Unknown solver %s" % solver)
 
-		# outputs
-		self.generated_inputs = []
-		self.execution_return_values = []
+        # outputs
+        self.generated_inputs = []
+        self.execution_return_values = []
 
-	def addConstraint(self, constraint):
-		self.constraints_to_solve.append(constraint)
-		# make sure to remember the input that led to this constraint
-		constraint.inputs = self._getInputs()
+    def addConstraint(self, constraint):
+        self.constraints_to_solve.append(constraint)
+        # make sure to remember the input that led to this constraint
+        constraint.inputs = self._getInputs()
 
-	def explore(self, max_iterations=0):
-		self._oneExecution()
-		
-		iterations = 1
-		if max_iterations != 0 and iterations >= max_iterations:
-			log.debug("Maximum number of iterations reached, terminating")
-			return self.execution_return_values
+    def explore(self, max_iterations=0):
+        self._oneExecution()
 
-		while not self._isExplorationComplete():
-			selected = self.constraints_to_solve.popleft()
-			if selected.processed:
-				continue
-			self._setInputs(selected.inputs)			
+        iterations = 1
+        if max_iterations != 0 and iterations >= max_iterations:
+            log.debug("Maximum number of iterations reached, terminating")
+            return self.execution_return_values
 
-			log.info("Selected constraint %s" % selected)
-			asserts, query = selected.getAssertsAndQuery()
-			model = self.solver.findCounterexample(asserts, query)
+        while not self._isExplorationComplete():
+            selected = self.constraints_to_solve.popleft()
+            if selected.processed:
+                continue
+            self._setInputs(selected.inputs)
 
-			if model == None:
-				continue
-			else:
-				for name in model.keys():
-					self._updateSymbolicParameter(name,model[name])
+            log.info("Selected constraint %s" % selected)
+            asserts, query = selected.getAssertsAndQuery()
+            model = self.solver.findCounterexample(asserts, query)
 
-			self._oneExecution(selected)
+            if model is None:
+                continue
+            else:
+                for name in model.keys():
+                    self._updateSymbolicParameter(name, model[name])
 
-			iterations += 1			
-			self.num_processed_constraints += 1
+            self._oneExecution(selected)
 
-			if max_iterations != 0 and iterations >= max_iterations:
-				log.info("Maximum number of iterations reached, terminating")
-				break
+            iterations += 1
+            self.num_processed_constraints += 1
 
-		return self.generated_inputs, self.execution_return_values, self.path
+            if max_iterations != 0 and iterations >= max_iterations:
+                log.info("Maximum number of iterations reached, terminating")
+                break
 
-	# private
+        return self.generated_inputs, self.execution_return_values, self.path
 
-	def _updateSymbolicParameter(self, name, val):
-		self.symbolic_inputs[name] = self.invocation.createArgumentValue(name,val)
+    # private
 
-	def _getInputs(self):
-		return self.symbolic_inputs.copy()
+    def _updateSymbolicParameter(self, name, val):
+        self.symbolic_inputs[name] = self.invocation.createArgumentValue(name, val)
 
-	def _setInputs(self,d):
-		self.symbolic_inputs = d
+    def _getInputs(self):
+        return self.symbolic_inputs.copy()
 
-	def _isExplorationComplete(self):
-		num_constr = len(self.constraints_to_solve)
-		if num_constr == 0:
-			log.info("Exploration complete")
-			return True
-		else:
-			log.info("%d constraints yet to solve (total: %d, already solved: %d)" % (num_constr, self.num_processed_constraints + num_constr, self.num_processed_constraints))
-			return False
+    def _setInputs(self, d):
+        self.symbolic_inputs = d
 
-	def _getConcrValue(self,v):
-		if isinstance(v,SymbolicType):
-			return v.getConcrValue()
-		else:
-			return v
+    def _isExplorationComplete(self):
+        num_constr = len(self.constraints_to_solve)
+        if num_constr == 0:
+            log.info("Exploration complete")
+            return True
+        else:
+            log.info("%d constraints yet to solve (total: %d, already solved: %d)" % (
+                num_constr, self.num_processed_constraints + num_constr, self.num_processed_constraints))
+            return False
 
-	def _recordInputs(self):
-		args = self.symbolic_inputs
-		inputs = [ (k,self._getConcrValue(args[k])) for k in args ]
-		self.generated_inputs.append(inputs)
-		print(inputs)
-		
-	def _oneExecution(self,expected_path=None):
-		self._recordInputs()
-		self.path.reset(expected_path)
-		ret = self.invocation.callFunction(self.symbolic_inputs)
-		print(ret)
-		self.execution_return_values.append(ret)
+    def _getConcrValue(self, v):
+        if isinstance(v, SymbolicType):
+            return v.getConcrValue()
+        else:
+            return v
 
+    def _recordInputs(self):
+        args = self.symbolic_inputs
+        inputs = [(k, self._getConcrValue(args[k])) for k in args]
+        self.generated_inputs.append(inputs)
+        print(inputs)
+
+    def _oneExecution(self, expected_path=None):
+        self._recordInputs()
+        self.path.reset(expected_path)
+        ret = self.invocation.callFunction(self.symbolic_inputs)
+        print(ret)
+        self.execution_return_values.append(ret)

--- a/symbolic/invocation.py
+++ b/symbolic/invocation.py
@@ -1,27 +1,25 @@
 # Copyright: see copyright.txt
 
+
 class FunctionInvocation:
-	def __init__(self, function, reset):
-		self.function = function
-		self.reset = reset
-		self.arg_constructor = {}
-		self.initial_value = {}
+    def __init__(self, function, reset):
+        self.function = function
+        self.reset = reset
+        self.arg_constructor = {}
+        self.initial_value = {}
 
-	def callFunction(self,args):
-		self.reset()
-		return self.function(**args)
+    def callFunction(self, args):
+        self.reset()
+        return self.function(**args)
 
-	def addArgumentConstructor(self, name, init, constructor):
-		self.initial_value[name] = init
-		self.arg_constructor[name] = constructor
+    def addArgumentConstructor(self, name, init, constructor):
+        self.initial_value[name] = init
+        self.arg_constructor[name] = constructor
 
-	def getNames(self):
-		return self.arg_constructor.keys()
+    def getNames(self):
+        return self.arg_constructor.keys()
 
-	def createArgumentValue(self,name,val=None):
-		if val == None:
-			val = self.initial_value[name]
-		return self.arg_constructor[name](name,val)
-
-	
-
+    def createArgumentValue(self, name, val=None):
+        if val is None:
+            val = self.initial_value[name]
+        return self.arg_constructor[name](name, val)

--- a/symbolic/loader.py
+++ b/symbolic/loader.py
@@ -10,124 +10,126 @@ from .symbolic_types import SymbolicInteger, getSymbolic
 # The built-in definition of len wraps the return value in an int() constructor, destroying any symbolic types.
 # By redefining len here we can preserve symbolic integer types.
 import builtins
-builtins.len = (lambda x : x.__len__())
+
+builtins.len = (lambda x: x.__len__())
+
 
 class Loader:
-	def __init__(self, filename, entry):
-		self._fileName = os.path.basename(filename)
-		self._fileName = self._fileName[:-3]
-		if (entry == ""):
-			self._entryPoint = self._fileName
-		else:
-			self._entryPoint = entry;
-		self._resetCallback(True)
+    def __init__(self, filename, entry):
+        self._fileName = os.path.basename(filename)
+        self._fileName = self._fileName[:-3]
+        if entry == "":
+            self._entryPoint = self._fileName
+        else:
+            self._entryPoint = entry
+        self._resetCallback(True)
 
-	def getFile(self):
-		return self._fileName
+    def getFile(self):
+        return self._fileName
 
-	def getEntry(self):
-		return self._entryPoint
-	
-	def createInvocation(self):
-		inv = FunctionInvocation(self._execute,self._resetCallback)
-		func = self.app.__dict__[self._entryPoint]
-		argspec = inspect.getargspec(func)
-		# check to see if user specified initial values of arguments
-		if "concrete_args" in func.__dict__:
-			for (f,v) in func.concrete_args.items():
-				if not f in argspec.args:
-					print("Error in @concrete: " +  self._entryPoint + " has no argument named " + f)
-					raise ImportError()
-				else:
-					Loader._initializeArgumentConcrete(inv,f,v)
-		if "symbolic_args" in func.__dict__:
-			for (f,v) in func.symbolic_args.items():
-				if not f in argspec.args:
-					print("Error (@symbolic): " +  self._entryPoint + " has no argument named " + f)
-					raise ImportError()
-				elif f in inv.getNames():
-					print("Argument " + f + " defined in both @concrete and @symbolic")
-					raise ImportError()
-				else:
-					s = getSymbolic(v)
-					if (s == None):
-						print("Error at argument " + f + " of entry point " + self._entryPoint + " : no corresponding symbolic type found for type " + str(type(v)))
-						raise ImportError()
-					Loader._initializeArgumentSymbolic(inv, f, v, s)
-		for a in argspec.args:
-			if not a in inv.getNames():
-				Loader._initializeArgumentSymbolic(inv, a, 0, SymbolicInteger)
-		return inv
+    def getEntry(self):
+        return self._entryPoint
 
-	# need these here (rather than inline above) to correctly capture values in lambda
-	def _initializeArgumentConcrete(inv,f,val):
-		inv.addArgumentConstructor(f, val, lambda n,v: val)
+    def createInvocation(self):
+        inv = FunctionInvocation(self._execute, self._resetCallback)
+        func = self.app.__dict__[self._entryPoint]
+        argspec = inspect.getargspec(func)
+        # check to see if user specified initial values of arguments
+        if "concrete_args" in func.__dict__:
+            for (f, v) in func.concrete_args.items():
+                if f not in argspec.args:
+                    print("Error in @concrete: " + self._entryPoint + " has no argument named " + f)
+                    raise ImportError()
+                else:
+                    Loader._initializeArgumentConcrete(inv, f, v)
+        if "symbolic_args" in func.__dict__:
+            for (f, v) in func.symbolic_args.items():
+                if f not in argspec.args:
+                    print("Error (@symbolic): " + self._entryPoint + " has no argument named " + f)
+                    raise ImportError()
+                elif f in inv.getNames():
+                    print("Argument " + f + " defined in both @concrete and @symbolic")
+                    raise ImportError()
+                else:
+                    s = getSymbolic(v)
+                    if s is None:
+                        print("Error at argument " + f + " of entry point " + self._entryPoint +
+                              " : no corresponding symbolic type found for type " + str(type(v)))
+                        raise ImportError()
+                    Loader._initializeArgumentSymbolic(inv, f, v, s)
+        for a in argspec.args:
+            if a not in inv.getNames():
+                Loader._initializeArgumentSymbolic(inv, a, 0, SymbolicInteger)
+        return inv
 
-	def _initializeArgumentSymbolic(inv,f,val,st):
-		inv.addArgumentConstructor(f, val, lambda n,v: st(n,v))
+    # need these here (rather than inline above) to correctly capture values in lambda
+    def _initializeArgumentConcrete(inv, f, val):
+        inv.addArgumentConstructor(f, val, lambda n, v: val)
 
-	def executionComplete(self, return_vals):
-		if "expected_result" in self.app.__dict__:
-			return self._check(return_vals, self.app.__dict__["expected_result"]())
-		if "expected_result_set" in self.app.__dict__:
-			return self._check(return_vals, self.app.__dict__["expected_result_set"](),False)
-		else:
-			print(self._fileName + ".py contains no expected_result function")
-			return None
+    def _initializeArgumentSymbolic(inv, f, val, st):
+        inv.addArgumentConstructor(f, val, lambda n, v: st(n, v))
 
-	# -- private
+    def executionComplete(self, return_vals):
+        if "expected_result" in self.app.__dict__:
+            return self._check(return_vals, self.app.__dict__["expected_result"]())
+        if "expected_result_set" in self.app.__dict__:
+            return self._check(return_vals, self.app.__dict__["expected_result_set"](), False)
+        else:
+            print(self._fileName + ".py contains no expected_result function")
+            return None
 
-	def _resetCallback(self,firstpass=False):
-		self.app = None
-		if firstpass and self._fileName in sys.modules:
-			print("There already is a module loaded named " + self._fileName)
-			raise ImportError()
-		try:
-			if (not firstpass and self._fileName in sys.modules):
-				del(sys.modules[self._fileName])
-			self.app =__import__(self._fileName)
-			if not self._entryPoint in self.app.__dict__ or not callable(self.app.__dict__[self._entryPoint]):
-				print("File " +  self._fileName + ".py doesn't contain a function named " + self._entryPoint)
-				raise ImportError()
-		except Exception as arg:
-			print("Couldn't import " + self._fileName)
-			print(arg)
-			raise ImportError()
+    # -- private
 
-	def _execute(self, **args):
-		return self.app.__dict__[self._entryPoint](**args)
+    def _resetCallback(self, firstpass=False):
+        self.app = None
+        if firstpass and self._fileName in sys.modules:
+            print("There already is a module loaded named " + self._fileName)
+            raise ImportError()
+        try:
+            if not firstpass and self._fileName in sys.modules:
+                del (sys.modules[self._fileName])
+            self.app = __import__(self._fileName)
+            if self._entryPoint not in self.app.__dict__ or not callable(self.app.__dict__[self._entryPoint]):
+                print("File " + self._fileName + ".py doesn't contain a function named " + self._entryPoint)
+                raise ImportError()
+        except Exception as arg:
+            print("Couldn't import " + self._fileName)
+            print(arg)
+            raise ImportError()
 
-	def _toBag(self,l):
-		bag = {}
-		for i in l:
-			if i in bag:
-				bag[i] += 1
-			else:
-				bag[i] = 1
-		return bag
+    def _execute(self, **args):
+        return self.app.__dict__[self._entryPoint](**args)
 
-	def _check(self, computed, expected, as_bag=True):
-		b_c = self._toBag(computed)
-		b_e = self._toBag(expected)
-		if as_bag and b_c != b_e or not as_bag and set(computed) != set(expected):
-			print("-------------------> %s test failed <---------------------" % self._fileName)
-			print("Expected: %s, found: %s" % (b_e, b_c))
-			return False
-		else:
-			print("%s test passed <---" % self._fileName)
-			return True
-	
-def loaderFactory(filename,entry):
-	if not os.path.isfile(filename) or not re.search(".py$",filename):
-		print("Please provide a Python file to load")
-		return None
-	try: 
-		dir = os.path.dirname(filename)
-		sys.path = [ dir ] + sys.path
-		ret = Loader(filename,entry)
-		return ret
-	except ImportError:
-		sys.path = sys.path[1:]
-		return None
+    def _toBag(self, l):
+        bag = {}
+        for i in l:
+            if i in bag:
+                bag[i] += 1
+            else:
+                bag[i] = 1
+        return bag
+
+    def _check(self, computed, expected, as_bag=True):
+        b_c = self._toBag(computed)
+        b_e = self._toBag(expected)
+        if as_bag and b_c != b_e or not as_bag and set(computed) != set(expected):
+            print("-------------------> %s test failed <---------------------" % self._fileName)
+            print("Expected: %s, found: %s" % (b_e, b_c))
+            return False
+        else:
+            print("%s test passed <---" % self._fileName)
+            return True
 
 
+def loaderFactory(filename, entry):
+    if not os.path.isfile(filename) or not re.search(".py$", filename):
+        print("Please provide a Python file to load")
+        return None
+    try:
+        directory = os.path.dirname(filename)
+        sys.path = [directory] + sys.path
+        ret = Loader(filename, entry)
+        return ret
+    except ImportError:
+        sys.path = sys.path[1:]
+        return None

--- a/symbolic/path_to_constraint.py
+++ b/symbolic/path_to_constraint.py
@@ -7,79 +7,79 @@ from .constraint import Constraint
 
 log = logging.getLogger("se.pathconstraint")
 
+
 class PathToConstraint:
-	def __init__(self, add):
-		self.constraints = {}
-		self.add = add
-		self.root_constraint = Constraint(None, None)
-		self.current_constraint = self.root_constraint
-		self.expected_path = None
+    def __init__(self, add):
+        self.constraints = {}
+        self.add = add
+        self.root_constraint = Constraint(None, None)
+        self.current_constraint = self.root_constraint
+        self.expected_path = None
 
-	def reset(self,expected):
-		self.current_constraint = self.root_constraint
-		if expected==None:
-			self.expected_path = None
-		else:
-			self.expected_path = []
-			tmp = expected
-			while tmp.predicate is not None:
-				self.expected_path.append(tmp.predicate)
-				tmp = tmp.parent
+    def reset(self, expected):
+        self.current_constraint = self.root_constraint
+        if expected is None:
+            self.expected_path = None
+        else:
+            self.expected_path = []
+            tmp = expected
+            while tmp.predicate is not None:
+                self.expected_path.append(tmp.predicate)
+                tmp = tmp.parent
 
-	def whichBranch(self, branch, symbolic_type):
-		""" This function acts as instrumentation.
-		Branch can be either True or False."""
+    def whichBranch(self, branch, symbolic_type):
+        """ This function acts as instrumentation.
+        Branch can be either True or False."""
 
-		# add both possible predicate outcomes to constraint (tree)
-		p = Predicate(symbolic_type, branch)
-		p.negate()
-		cneg = self.current_constraint.findChild(p)
-		p.negate()
-		c = self.current_constraint.findChild(p)
+        # add both possible predicate outcomes to constraint (tree)
+        p = Predicate(symbolic_type, branch)
+        p.negate()
+        cneg = self.current_constraint.findChild(p)
+        p.negate()
+        c = self.current_constraint.findChild(p)
 
-		if c is None:
-			c = self.current_constraint.addChild(p)
+        if c is None:
+            c = self.current_constraint.addChild(p)
 
-			# we add the new constraint to the queue of the engine for later processing
-			log.debug("New constraint: %s" % c)
-			self.add(c)
-			
-		# check for path mismatch
-		# IMPORTANT: note that we don't actually check the predicate is the
-		# same one, just that the direction taken is the same
-		if self.expected_path != None and self.expected_path != []:
-			expected = self.expected_path.pop()
-			# while not at the end of the path, we expect the same predicate result
-			# at the end of the path, we expect a different predicate result
-			done = self.expected_path == []
-			if ( not done and expected.result != c.predicate.result or \
-				done and expected.result == c.predicate.result ):
-				print("Replay mismatch (done=",done,")")
-				print(expected)
-				print(c.predicate)
+            # we add the new constraint to the queue of the engine for later processing
+            log.debug("New constraint: %s" % c)
+            self.add(c)
 
-		if cneg is not None:
-			# We've already processed both
-			cneg.processed = True
-			c.processed = True
-			log.debug("Processed constraint: %s" % c)
+        # check for path mismatch
+        # IMPORTANT: note that we don't actually check the predicate is the
+        # same one, just that the direction taken is the same
+        if self.expected_path is not None and self.expected_path != []:
+            expected = self.expected_path.pop()
+            # while not at the end of the path, we expect the same predicate result
+            # at the end of the path, we expect a different predicate result
+            done = self.expected_path == []
+            if (not done and expected.result != c.predicate.result or
+                            done and expected.result == c.predicate.result):
+                print("Replay mismatch (done=", done, ")")
+                print(expected)
+                print(c.predicate)
 
-		self.current_constraint = c
+        if cneg is not None:
+            # We've already processed both
+            cneg.processed = True
+            c.processed = True
+            log.debug("Processed constraint: %s" % c)
 
-	def toDot(self):
-		# print the thing into DOT format
-		header = "digraph {\n"
-		footer = "\n}\n"
-		return header + self._toDot(self.root_constraint) + footer
+        self.current_constraint = c
 
-	def _toDot(self,c):
-		if (c.parent == None):
-			label = "root"
-		else:
-			label = c.predicate.symtype.toString()
-			if not c.predicate.result:
-				label = "Not("+label+")"
-		node = "C" + str(c.id) + " [ label=\"" + label + "\" ];\n"
-		edges = [ "C" + str(c.id) + " -> " + "C" + str(child.id) + ";\n" for child in c.children ]
-		return node + "".join(edges) + "".join([ self._toDot(child) for child in c.children ])
-		
+    def toDot(self):
+        # print the thing into DOT format
+        header = "digraph {\n"
+        footer = "\n}\n"
+        return header + self._toDot(self.root_constraint) + footer
+
+    def _toDot(self, c):
+        if c.parent is None:
+            label = "root"
+        else:
+            label = c.predicate.symtype.toString()
+            if not c.predicate.result:
+                label = "Not(" + label + ")"
+        node = "C" + str(c.id) + " [ label=\"" + label + "\" ];\n"
+        edges = ["C" + str(c.id) + " -> " + "C" + str(child.id) + ";\n" for child in c.children]
+        return node + "".join(edges) + "".join([self._toDot(child) for child in c.children])

--- a/symbolic/predicate.py
+++ b/symbolic/predicate.py
@@ -1,33 +1,34 @@
 # Copyright - see copyright.txt
 
+
 class Predicate:
-	"""Predicate is one specific ``if'' encountered during the program execution.
-	   """
-	def __init__(self, st, result):
-		self.symtype = st
-		self.result = result
+    """Predicate is one specific ``if'' encountered during the program execution.
+       """
 
-	def getVars(self):
-		return self.symtype.getVars()
+    def __init__(self, st, result):
+        self.symtype = st
+        self.result = result
 
-	def __eq__(self, other):
-		if isinstance(other, Predicate):
-			res = self.result == other.result and self.symtype.symbolicEq(other.symtype)
-			return res
-		else:
-			return False
+    def getVars(self):
+        return self.symtype.getVars()
 
-	def __hash__(self):
-		return hash(self.symtype)
+    def __eq__(self, other):
+        if isinstance(other, Predicate):
+            res = self.result == other.result and self.symtype.symbolicEq(other.symtype)
+            return res
+        else:
+            return False
 
-	def __str__(self):
-		return self.symtype.toString() + " (%s)" % (self.result)
+    def __hash__(self):
+        return hash(self.symtype)
 
-	def __repr__(self):
-		return self.__str__()
+    def __str__(self):
+        return self.symtype.toString() + " (%s)" % (self.result)
 
-	def negate(self):
-		"""Negates the current predicate"""
-		assert(self.result is not None)
-		self.result = not self.result
+    def __repr__(self):
+        return self.__str__()
 
+    def negate(self):
+        """Negates the current predicate"""
+        assert (self.result is not None)
+        self.result = not self.result

--- a/symbolic/symbolic_types/__init__.py
+++ b/symbolic/symbolic_types/__init__.py
@@ -6,18 +6,16 @@ from .symbolic_dict import SymbolicDict as SymD
 from .symbolic_str import SymbolicStr as SymS
 from .symbolic_type import SymbolicType as SymType
 
-SymObj.wrap = lambda conc, sym : SymbolicInteger("se",conc,sym)
+SymObj.wrap = lambda conc, sym: SymbolicInteger("se", conc, sym)
 SymbolicInteger = SymInt
 SymbolicDict = SymD
 SymbolicStr = SymS
 SymbolicType = SymType
 
+
 def getSymbolic(v):
-	exported = [(int,SymbolicInteger),(dict,SymbolicDict),(str,SymbolicStr)]
-	for (t,s) in exported:
-		if isinstance(v,t):
-			return s
-	return None
-
-
-
+    exported = [(int, SymbolicInteger), (dict, SymbolicDict), (str, SymbolicStr)]
+    for (t, s) in exported:
+        if isinstance(v, t):
+            return s
+    return None

--- a/symbolic/symbolic_types/symbolic_dict.py
+++ b/symbolic/symbolic_types/symbolic_dict.py
@@ -1,6 +1,7 @@
 import ast
 import sys
-from . symbolic_type import SymbolicObject
+from .symbolic_type import SymbolicObject
+
 
 # SymbolicDict: the key and values will both be SymbolicType for full generality
 
@@ -10,22 +11,22 @@ from . symbolic_type import SymbolicObject
 
 # TODO: big simplification: can only initialize with
 # an empty dictionary
-class SymbolicDict(SymbolicObject,dict):
-	def __new__(cls, name, *args, **kwargs):
-		self = dict.__new__(cls,args,kwargs)
-		return self
+class SymbolicDict(SymbolicObject, dict):
+    def __new__(cls, name, *args, **kwargs):
+        self = dict.__new__(cls, args, kwargs)
+        return self
 
-	def __init__(self, name, kwargs):
-		SymbolicObject.__init__(self,name,None)
-		dict.__init__(self,kwargs)
+    def __init__(self, name, kwargs):
+        SymbolicObject.__init__(self, name, None)
+        dict.__init__(self, kwargs)
 
-	def getConcrValue(self):
-		return self
-		
-	def __bool__(self):
-		return bool(len(self))
+    def getConcrValue(self):
+        return self
 
-#	def wrap(conc,sym):
+    def __bool__(self):
+        return bool(len(self))
+
+# def wrap(conc,sym):
 #		pass # TODO
 
 #	def __getitem__(self,key):
@@ -55,4 +56,3 @@ class SymbolicDict(SymbolicObject,dict):
 #			pass
 #			# self.expr = Delete(self.expr,key)
 #		dict.__delitem__(self,key)
-

--- a/symbolic/symbolic_types/symbolic_int.py
+++ b/symbolic/symbolic_types/symbolic_int.py
@@ -1,58 +1,61 @@
 # Copyright: copyright.txt
 
-from . symbolic_type import SymbolicObject
+from .symbolic_type import SymbolicObject
+
 
 # we use multiple inheritance to achieve concrete execution for any
 # operation for which we don't have a symbolic representation. As
 # we can see a SymbolicInteger is both symbolic (SymbolicObject) and 
 # concrete (int)
 
-class SymbolicInteger(SymbolicObject,int):
-	# since we are inheriting from int, we need to use new
-	# to perform construction correctly
-	def __new__(cls, name, v, expr=None):
-		return int.__new__(cls, v)
+class SymbolicInteger(SymbolicObject, int):
+    # since we are inheriting from int, we need to use new
+    # to perform construction correctly
+    def __new__(cls, name, v, expr=None):
+        return int.__new__(cls, v)
 
-	def __init__(self, name, v, expr=None):
-		SymbolicObject.__init__(self, name, expr)
-		self.val = v
+    def __init__(self, name, v, expr=None):
+        SymbolicObject.__init__(self, name, expr)
+        self.val = v
 
-	def getConcrValue(self):
-		return self.val
+    def getConcrValue(self):
+        return self.val
 
-	def wrap(conc,sym):
-		return SymbolicInteger("se",conc,sym)
+    def wrap(conc, sym):
+        return SymbolicInteger("se", conc, sym)
 
-	def __hash__(self):
-		return hash(self.val)
+    def __hash__(self):
+        return hash(self.val)
 
-	def _op_worker(self,args,fun,op):
-		return self._do_sexpr(args, fun, op, SymbolicInteger.wrap)
+    def _op_worker(self, args, fun, op):
+        return self._do_sexpr(args, fun, op, SymbolicInteger.wrap)
+
 
 # now update the SymbolicInteger class for operations we
 # will build symbolic terms for
 
-ops =  [("add",    "+"  ),\
-	("sub",    "-"  ),\
-	("mul",    "*"  ),\
-	("mod",    "%"  ),\
-	("floordiv", "//" ),\
-	("and",    "&"  ),\
-	("or",     "|"  ),\
-	("xor",    "^"  ),\
-	("lshift", "<<" ),\
-	("rshift", ">>" ) ]
+ops = [("add", "+"),
+       ("sub", "-"),
+       ("mul", "*"),
+       ("mod", "%"),
+       ("floordiv", "//"),
+       ("and", "&"),
+       ("or", "|"),
+       ("xor", "^"),
+       ("lshift", "<<"),
+       ("rshift", ">>")]
 
-def make_method(method,op,a):
-	code  = "def %s(self,other):\n" % method
-	code += "   return self._op_worker(%s,lambda x,y : x %s y, \"%s\")" % (a,op,op)
-	locals_dict = {}
-	exec(code, globals(), locals_dict)
-	setattr(SymbolicInteger,method,locals_dict[method])
 
-for (name,op) in ops:
-	method  = "__%s__" % name
-	make_method(method,op,"[self,other]")
-	rmethod  = "__r%s__" % name
-	make_method(rmethod,op,"[other,self]")
+def make_method(method, op, a):
+    code = "def %s(self,other):\n" % method
+    code += "   return self._op_worker(%s,lambda x,y : x %s y, \"%s\")" % (a, op, op)
+    locals_dict = {}
+    exec(code, globals(), locals_dict)
+    setattr(SymbolicInteger, method, locals_dict[method])
 
+
+for (name, op) in ops:
+    method = "__%s__" % name
+    make_method(method, op, "[self,other]")
+    rmethod = "__r%s__" % name
+    make_method(rmethod, op, "[other,self]")

--- a/symbolic/symbolic_types/symbolic_str.py
+++ b/symbolic/symbolic_types/symbolic_str.py
@@ -24,7 +24,6 @@ class SymbolicStr(SymbolicObject, str):
         return self._do_sexpr(args, fun, op, SymbolicStr.wrap)
 
     def __bool__(self):
-        # noinspection PyCallByClass,PyTypeChecker
         return SymbolicObject.__bool__(self.__len__() != 0)
 
     def __len__(self):

--- a/symbolic/symbolic_types/symbolic_str.py
+++ b/symbolic/symbolic_types/symbolic_str.py
@@ -1,9 +1,9 @@
-from . symbolic_type import SymbolicObject
+from .symbolic_type import SymbolicObject
 from symbolic.symbolic_types.symbolic_int import SymbolicInteger
 from string import whitespace
 
-class SymbolicStr(SymbolicObject, str):
 
+class SymbolicStr(SymbolicObject, str):
     def __new__(cls, name, v, expr=None):
         return str.__new__(cls, v)
 
@@ -24,15 +24,16 @@ class SymbolicStr(SymbolicObject, str):
         return self._do_sexpr(args, fun, op, SymbolicStr.wrap)
 
     def __bool__(self):
+        # noinspection PyCallByClass,PyTypeChecker
         return SymbolicObject.__bool__(self.__len__() != 0)
 
     def __len__(self):
         return self._do_sexpr([self], lambda x: len(x),
-                                "str.len", SymbolicInteger.wrap)
+                              "str.len", SymbolicInteger.wrap)
 
     def __contains__(self, item):
         return self._do_sexpr([self, item], lambda x, y: str.__contains__(x, y),
-                                "in", SymbolicInteger.wrap)
+                              "in", SymbolicInteger.wrap)
 
     def __getitem__(self, key):
         """Negative indexes, out of bound slices, and slice skips are not currently supported."""
@@ -97,7 +98,7 @@ class SymbolicStr(SymbolicObject, str):
             first_half = self[:pivot_point]
             first_half = first_half._replace(old, new)
             second_half = self[pivot_point:]
-            ret = first_half + second_half.replace(old, new, maxreplace-1)
+            ret = first_half + second_half.replace(old, new, maxreplace - 1)
         assert str(ret) == str.replace(str(self), str(old), str(new), int(maxreplace))
         return ret
 
@@ -114,19 +115,21 @@ class SymbolicStr(SymbolicObject, str):
                 return self[:self.__len__() - 1].strip(chars)
         return self
 
+
 # Currently only a subset of string operations are supported.
 ops = [("add", "+")]
 
-def make_method(method,op,a):
-    code  = "def %s(self,other):\n" % method
-    code += "   return self._op_worker(%s,lambda x,y : x %s y, \"%s\")" % (a,op,op)
+
+def make_method(method, op, a):
+    code = "def %s(self,other):\n" % method
+    code += "   return self._op_worker(%s,lambda x,y : x %s y, \"%s\")" % (a, op, op)
     locals_dict = {}
     exec(code, globals(), locals_dict)
     setattr(SymbolicStr, method, locals_dict[method])
 
-for (name,op) in ops:
-    method  = "__%s__" % name
-    make_method(method,op,"[self,other]")
-    rmethod  = "__r%s__" % name
-    make_method(rmethod,op,"[other,self]")
 
+for (name, op) in ops:
+    method = "__%s__" % name
+    make_method(method, op, "[self,other]")
+    rmethod = "__r%s__" % name
+    make_method(rmethod, op, "[other,self]")

--- a/symbolic/symbolic_types/symbolic_type.py
+++ b/symbolic/symbolic_types/symbolic_type.py
@@ -1,139 +1,138 @@
 # Copyright: see copyright.txt
 
-import utils
 import inspect
 import functools
+
 
 # the ABSTRACT base class for representing any expression that depends on a symbolic input
 # it also tracks the corresponding concrete value for the expression (aka concolic execution)
 
 class SymbolicType(object):
-	def __init__(self, name, expr=None):
-		self.name = name
-		self.expr = expr
+    def __init__(self, name, expr=None):
+        self.name = name
+        self.expr = expr
 
-	# to be provided by subclass
+    # to be provided by subclass
 
-	def getConcrValue(self):
-		raise NotImplemented()
+    def getConcrValue(self):
+        raise NotImplemented()
 
-	def wrap(conc,sym):
-		raise NotImplemented()
+    def wrap(conc, sym):
+        raise NotImplemented()
 
-	# public funs
+    # public funs
 
-	def isVariable(self):
-		return self.expr == None
+    def isVariable(self):
+        return self.expr is None
 
-	def unwrap(self):
-		if self.isVariable():
-			return (self.getConcrValue(),self)
-		else:
-			return (self.getConcrValue(),self.expr)
+    def unwrap(self):
+        if self.isVariable():
+            return self.getConcrValue(), self
+        else:
+            return self.getConcrValue(), self.expr
 
-	def getVars(self):
-		if self.isVariable():
-			return [self.name]
-		elif isinstance(self.expr,list):
-			return self._getVarsLeaves(self.expr)
-		else:
-			return []
+    def getVars(self):
+        if self.isVariable():
+            return [self.name]
+        elif isinstance(self.expr, list):
+            return self._getVarsLeaves(self.expr)
+        else:
+            return []
 
-	def _getVarsLeaves(self,l):
-		if isinstance(l,list):
-			return functools.reduce(lambda a, x: self._getVarsLeaves(x) + a,l,[])
-		elif isinstance(l,SymbolicType):
-			return [l.name]
-		else:
-			return []
+    def _getVarsLeaves(self, l):
+        if isinstance(l, list):
+            return functools.reduce(lambda a, x: self._getVarsLeaves(x) + a, l, [])
+        elif isinstance(l, SymbolicType):
+            return [l.name]
+        else:
+            return []
 
-	# creating the expression tree
-	def _do_sexpr(self,args,fun,op,wrap):
-		unwrapped = [ (a.unwrap() if isinstance(a,SymbolicType) else (a,a)) for a in args ]
-		args = zip(inspect.getargspec(fun).args, [ c for (c,s) in unwrapped ])
-		concrete = fun(**dict([a for a in args]))
-		symbolic = [ op ] + [ s for c,s in unwrapped ]
-		return wrap(concrete,symbolic)
+    # creating the expression tree
+    def _do_sexpr(self, args, fun, op, wrap):
+        unwrapped = [(a.unwrap() if isinstance(a, SymbolicType) else (a, a)) for a in args]
+        args = zip(inspect.getargspec(fun).args, [c for (c, s) in unwrapped])
+        concrete = fun(**dict([a for a in args]))
+        symbolic = [op] + [s for c, s in unwrapped]
+        return wrap(concrete, symbolic)
 
-	def symbolicEq(self, other):
-		if not isinstance(other,SymbolicType):
-			return False
-		if self.isVariable() or other.isVariable():
-			return self.name == other.name
-		return self._eq_worker(self.expr,other.expr)
+    def symbolicEq(self, other):
+        if not isinstance(other, SymbolicType):
+            return False
+        if self.isVariable() or other.isVariable():
+            return self.name == other.name
+        return self._eq_worker(self.expr, other.expr)
 
-	def _eq_worker(self, expr1, expr2):
-		if type(expr1) != type(expr2):
-			return False
-		if isinstance(expr1, list):
-			return len(expr1) == len(expr2) and\
-			       type(expr1[0]) == type(expr2[0]) and\
-                               all([ self._eq_worker(x,y) for x,y in zip(expr1[1:],expr2[1:]) ])
-		elif isinstance(expr1, SymbolicType):
-			return expr1.name == expr2.name
-		else:
-			return expr1 == expr2
+    def _eq_worker(self, expr1, expr2):
+        if type(expr1) != type(expr2):
+            return False
+        if isinstance(expr1, list):
+            return len(expr1) == len(expr2) and \
+                   type(expr1[0]) == type(expr2[0]) and \
+                   all([self._eq_worker(x, y) for x, y in zip(expr1[1:], expr2[1:])])
+        elif isinstance(expr1, SymbolicType):
+            return expr1.name == expr2.name
+        else:
+            return expr1 == expr2
 
-	def toString(self):
-		if self.isVariable():
-			return self.name + "#" + str(self.getConcrValue())
-		else:
-			return self._toString(self.expr)
+    def toString(self):
+        if self.isVariable():
+            return self.name + "#" + str(self.getConcrValue())
+        else:
+            return self._toString(self.expr)
 
-	def _toString(self,expr):
-		if isinstance(expr,list):
-			return "(" + expr[0] + " " + ", ".join([ self._toString(a) for a in expr[1:] ]) + ")"
-		elif isinstance(expr,SymbolicType):
-			return expr.toString()
-		else:
-			return str(expr)
+    def _toString(self, expr):
+        if isinstance(expr, list):
+            return "(" + expr[0] + " " + ", ".join([self._toString(a) for a in expr[1:]]) + ")"
+        elif isinstance(expr, SymbolicType):
+            return expr.toString()
+        else:
+            return str(expr)
+
 
 # this class is also ABSTRACT although __init__.py does
 # initialize wrap to return SymbolicInteger for the 
 # relational comparison operators
 
-class SymbolicObject(SymbolicType,object): 
-	def __init__(self, name, expr=None):
-		SymbolicType.__init__(self,name,expr)
+class SymbolicObject(SymbolicType, object):
+    def __init__(self, name, expr=None):
+        SymbolicType.__init__(self, name, expr)
 
-	SI = None    # this is set up by ConcolicEngine to link __bool__ to PathConstraint
+    SI = None  # this is set up by ConcolicEngine to link __bool__ to PathConstraint
 
-	def wrap(conc,sym):
-		# see __init__.py
-		raise NotImplemented()
+    def wrap(conc, sym):
+        # see __init__.py
+        raise NotImplemented()
 
-	# this is a critical interception point: the __bool__
-	# method is called whenever a predicate is evaluated in
-	# Python execution (if, while, and, or). This allows us
-	# to capture the path condition
+    # this is a critical interception point: the __bool__
+    # method is called whenever a predicate is evaluated in
+    # Python execution (if, while, and, or). This allows us
+    # to capture the path condition
 
-	def __bool__(self):
-		ret = bool(self.getConcrValue())
-		if SymbolicObject.SI != None:
-			SymbolicObject.SI.whichBranch(ret,self)
-		return ret
+    def __bool__(self):
+        ret = bool(self.getConcrValue())
+        if SymbolicObject.SI is not None:
+            SymbolicObject.SI.whichBranch(ret, self)
+        return ret
 
-	# compute both the symbolic and concrete image of operator
-	def _do_bin_op(self, other, fun, op, wrap):
-		return self._do_sexpr([self,other], fun, op, wrap)
+    # compute both the symbolic and concrete image of operator
+    def _do_bin_op(self, other, fun, op, wrap):
+        return self._do_sexpr([self, other], fun, op, wrap)
 
-	def __eq__(self, other):
-		# TODO: what it self is not symbolic and other is???
-		return self._do_bin_op(other, lambda x, y: x == y, "==", SymbolicObject.wrap)
+    def __eq__(self, other):
+        # TODO: what it self is not symbolic and other is???
+        return self._do_bin_op(other, lambda x, y: x == y, "==", SymbolicObject.wrap)
 
-	def __ne__(self, other):
-		return self._do_bin_op(other, lambda x, y: x != y, "!=", SymbolicObject.wrap)
+    def __ne__(self, other):
+        return self._do_bin_op(other, lambda x, y: x != y, "!=", SymbolicObject.wrap)
 
-	def __lt__(self, other):
-		return self._do_bin_op(other, lambda x, y: x < y, "<", SymbolicObject.wrap)
+    def __lt__(self, other):
+        return self._do_bin_op(other, lambda x, y: x < y, "<", SymbolicObject.wrap)
 
-	def __le__(self, other):
-		return self._do_bin_op(other, lambda x, y: x <= y, "<=", SymbolicObject.wrap)
+    def __le__(self, other):
+        return self._do_bin_op(other, lambda x, y: x <= y, "<=", SymbolicObject.wrap)
 
-	def __gt__(self, other):
-		return self._do_bin_op(other, lambda x, y: x > y, ">", SymbolicObject.wrap)
+    def __gt__(self, other):
+        return self._do_bin_op(other, lambda x, y: x > y, ">", SymbolicObject.wrap)
 
-	def __ge__(self, other):
-		return self._do_bin_op(other, lambda x, y: x >= y, ">=", SymbolicObject.wrap)
-
-
+    def __ge__(self, other):
+        return self._do_bin_op(other, lambda x, y: x >= y, ">=", SymbolicObject.wrap)

--- a/symbolic/z3_expr/bitvector.py
+++ b/symbolic/z3_expr/bitvector.py
@@ -1,16 +1,17 @@
 from z3 import *
 from .expression import Z3Expression
 
+
 class Z3BitVector(Z3Expression):
-	def __init__(self,N):
-		Z3Expression.__init__(self)
-		self.N = N
+    def __init__(self, N):
+        Z3Expression.__init__(self)
+        self.N = N
 
-	def _isIntVar(self,v):
-		return isinstance(v,BitVecRef)
+    def _isIntVar(self, v):
+        return isinstance(v, BitVecRef)
 
-	def _variable(self,name,solver):
-		return BitVec(name,self.N,solver.ctx)
+    def _variable(self, name, solver):
+        return BitVec(name, self.N, solver.ctx)
 
-	def _constant(self,v,solver):
-		return BitVecVal(v,self.N,solver.ctx)
+    def _constant(self, v, solver):
+        return BitVecVal(v, self.N, solver.ctx)

--- a/symbolic/z3_expr/expression.py
+++ b/symbolic/z3_expr/expression.py
@@ -4,146 +4,147 @@ from symbolic.symbolic_types.symbolic_int import SymbolicInteger
 from symbolic.symbolic_types.symbolic_type import SymbolicType
 from z3 import *
 
+
 class Z3Expression(object):
-	def __init__(self):
-		self.z3_vars = {}
+    def __init__(self):
+        self.z3_vars = {}
 
-	def toZ3(self,solver,asserts,query):
-		self.z3_vars = {}
-		solver.assert_exprs([self.predToZ3(p,solver) for p in asserts])
-		solver.assert_exprs(Not(self.predToZ3(query,solver)))
+    def toZ3(self, solver, asserts, query):
+        self.z3_vars = {}
+        solver.assert_exprs([self.predToZ3(p, solver) for p in asserts])
+        solver.assert_exprs(Not(self.predToZ3(query, solver)))
 
-	def predToZ3(self,pred,solver,env=None):
-		sym_expr = self._astToZ3Expr(pred.symtype,solver,env)
-		if env == None:
-			if not is_bool(sym_expr):
-				sym_expr = sym_expr != self._constant(0,solver)
-			if not pred.result:
-				sym_expr = Not(sym_expr)
-		else:
-			if not pred.result:
-				sym_expr = not sym_expr
-		return sym_expr
+    def predToZ3(self, pred, solver, env=None):
+        sym_expr = self._astToZ3Expr(pred.symtype, solver, env)
+        if env is None:
+            if not is_bool(sym_expr):
+                sym_expr = sym_expr != self._constant(0, solver)
+            if not pred.result:
+                sym_expr = Not(sym_expr)
+        else:
+            if not pred.result:
+                sym_expr = not sym_expr
+        return sym_expr
 
-	def getIntVars(self):
-		return [ v[1] for v in self.z3_vars.items() if self._isIntVar(v[1]) ]
+    def getIntVars(self):
+        return [v[1] for v in self.z3_vars.items() if self._isIntVar(v[1])]
 
-	# ----------- private ---------------
+    # ----------- private ---------------
 
-	def _isIntVar(self, v):
-		raise NotImplementedException
+    def _isIntVar(self, v):
+        raise NotImplementedException
 
-	def _getIntegerVariable(self,name,solver):
-		if name not in self.z3_vars:
-			self.z3_vars[name] = self._variable(name,solver)
-		return self.z3_vars[name]
+    def _getIntegerVariable(self, name, solver):
+        if name not in self.z3_vars:
+            self.z3_vars[name] = self._variable(name, solver)
+        return self.z3_vars[name]
 
-	def _variable(self,name,solver):
-		raise NotImplementedException
+    def _variable(self, name, solver):
+        raise NotImplementedException
 
-	def _constant(self,v,solver):
-		raise NotImplementedException
+    def _constant(self, v, solver):
+        raise NotImplementedException
 
-	def _wrapIf(self,e,solver,env):
-		if env == None:
-			return If(e,self._constant(1,solver),self._constant(0,solver))
-		else:
-			return e
+    def _wrapIf(self, e, solver, env):
+        if env is None:
+            return If(e, self._constant(1, solver), self._constant(0, solver))
+        else:
+            return e
 
-	# add concrete evaluation to this, to check
-	def _astToZ3Expr(self,expr,solver,env=None):
-		if isinstance(expr, list):
-			op = expr[0]
-			args = [ self._astToZ3Expr(a,solver,env) for a in expr[1:] ]
-			z3_l,z3_r = args[0],args[1]
+    # add concrete evaluation to this, to check
+    def _astToZ3Expr(self, expr, solver, env=None):
+        if isinstance(expr, list):
+            op = expr[0]
+            args = [self._astToZ3Expr(a, solver, env) for a in expr[1:]]
+            z3_l, z3_r = args[0], args[1]
 
-			# arithmetical operations
-			if op == "+":
-				return self._add(z3_l, z3_r, solver)
-			elif op == "-":
-				return self._sub(z3_l, z3_r, solver)
-			elif op == "*":
-				return self._mul(z3_l, z3_r, solver)
-			elif op == "//":
-				return self._div(z3_l, z3_r, solver)
-			elif op == "%":
-				return self._mod(z3_l, z3_r, solver)
+            # arithmetical operations
+            if op == "+":
+                return self._add(z3_l, z3_r, solver)
+            elif op == "-":
+                return self._sub(z3_l, z3_r, solver)
+            elif op == "*":
+                return self._mul(z3_l, z3_r, solver)
+            elif op == "//":
+                return self._div(z3_l, z3_r, solver)
+            elif op == "%":
+                return self._mod(z3_l, z3_r, solver)
 
-			# bitwise
-			elif op == "<<":
-				return self._lsh(z3_l, z3_r, solver)
-			elif op == ">>":
-				return self._rsh(z3_l, z3_r, solver)
-			elif op == "^":
-				return self._xor(z3_l, z3_r, solver)
-			elif op == "|":
-				return self._or(z3_l, z3_r, solver)
-			elif op == "&":
-				return self._and(z3_l, z3_r, solver)
+            # bitwise
+            elif op == "<<":
+                return self._lsh(z3_l, z3_r, solver)
+            elif op == ">>":
+                return self._rsh(z3_l, z3_r, solver)
+            elif op == "^":
+                return self._xor(z3_l, z3_r, solver)
+            elif op == "|":
+                return self._or(z3_l, z3_r, solver)
+            elif op == "&":
+                return self._and(z3_l, z3_r, solver)
 
-			# equality gets coerced to integer
-			elif op == "==":
-				return self._wrapIf(z3_l == z3_r,solver,env)
-			elif op == "!=":
-				return self._wrapIf(z3_l != z3_r,solver,env)
-			elif op == "<":
-				return self._wrapIf(z3_l < z3_r,solver,env)
-			elif op == ">":
-				return self._wrapIf(z3_l > z3_r,solver,env)
-			elif op == "<=":
-				return self._wrapIf(z3_l <= z3_r,solver,env)
-			elif op == ">=":
-				return self._wrapIf(z3_l >= z3_r,solver,env)
-			else:
-				utils.crash("Unknown BinOp during conversion from ast to Z3 (expressions): %s" % op)
+            # equality gets coerced to integer
+            elif op == "==":
+                return self._wrapIf(z3_l == z3_r, solver, env)
+            elif op == "!=":
+                return self._wrapIf(z3_l != z3_r, solver, env)
+            elif op == "<":
+                return self._wrapIf(z3_l < z3_r, solver, env)
+            elif op == ">":
+                return self._wrapIf(z3_l > z3_r, solver, env)
+            elif op == "<=":
+                return self._wrapIf(z3_l <= z3_r, solver, env)
+            elif op == ">=":
+                return self._wrapIf(z3_l >= z3_r, solver, env)
+            else:
+                utils.crash("Unknown BinOp during conversion from ast to Z3 (expressions): %s" % op)
 
-		elif isinstance(expr, SymbolicInteger):
-			if expr.isVariable():
-				if env == None:
-					return self._getIntegerVariable(expr.name,solver)
-				else:
-					return env[expr.name]
-			else:
-				return self._astToZ3Expr(expr.expr,solver,env)
+        elif isinstance(expr, SymbolicInteger):
+            if expr.isVariable():
+                if env is None:
+                    return self._getIntegerVariable(expr.name, solver)
+                else:
+                    return env[expr.name]
+            else:
+                return self._astToZ3Expr(expr.expr, solver, env)
 
-		elif isinstance(expr, SymbolicType):
-			utils.crash("{} is an unsupported SymbolicType of {}".
-						format(expr, type(expr)))
+        elif isinstance(expr, SymbolicType):
+            utils.crash("{} is an unsupported SymbolicType of {}".
+                        format(expr, type(expr)))
 
-		elif isinstance(expr, int):
-			if env == None:
-				return self._constant(expr,solver)
-			else:
-				return expr
-		else:
-			utils.crash("Unknown node during conversion from ast to Z3 (expressions): %s" % expr)
+        elif isinstance(expr, int):
+            if env is None:
+                return self._constant(expr, solver)
+            else:
+                return expr
+        else:
+            utils.crash("Unknown node during conversion from ast to Z3 (expressions): %s" % expr)
 
-	def _add(self, l, r, solver):
-		return l + r
+    def _add(self, l, r, solver):
+        return l + r
 
-	def _sub(self, l, r, solver):
-		return l - r
+    def _sub(self, l, r, solver):
+        return l - r
 
-	def _mul(self, l, r, solver):
-		return l * r
+    def _mul(self, l, r, solver):
+        return l * r
 
-	def _div(self, l, r, solver):
-		return l / r
+    def _div(self, l, r, solver):
+        return l / r
 
-	def _mod(self, l, r, solver):
-		return l % r
+    def _mod(self, l, r, solver):
+        return l % r
 
-	def _lsh(self, l, r, solver):
-		return l << r
+    def _lsh(self, l, r, solver):
+        return l << r
 
-	def _rsh(self, l, r, solver):
-		return l >> r
+    def _rsh(self, l, r, solver):
+        return l >> r
 
-	def _xor(self, l, r, solver):
-		return l ^ r
+    def _xor(self, l, r, solver):
+        return l ^ r
 
-	def _or(self, l, r, solver):
-		return l | r
+    def _or(self, l, r, solver):
+        return l | r
 
-	def _and(self, l, r, solver):
-		return l & r
+    def _and(self, l, r, solver):
+        return l & r

--- a/symbolic/z3_expr/integer.py
+++ b/symbolic/z3_expr/integer.py
@@ -1,36 +1,37 @@
 from z3 import *
 from .expression import Z3Expression
 
+
 class Z3Integer(Z3Expression):
-	def _isIntVar(self,v):
-		return isinstance(v,IntRef)
+    def _isIntVar(self, v):
+        return isinstance(v, IntRef)
 
-	def _variable(self,name,solver):
-		return Int(name,solver.ctx)
+    def _variable(self, name, solver):
+        return Int(name, solver.ctx)
 
-	def _constant(self,v,solver):
-		return IntVal(v,solver.ctx)
+    def _constant(self, v, solver):
+        return IntVal(v, solver.ctx)
 
-	def _mod(self, l, r, solver):
-		mod_fun = Function('int_mod', IntSort(), IntSort(), IntSort())
-		return mod_fun(l, r)
+    def _mod(self, l, r, solver):
+        mod_fun = Function('int_mod', IntSort(), IntSort(), IntSort())
+        return mod_fun(l, r)
 
-	def _lsh(self, l, r, solver):
-		lsh_fun = Function('int_lsh', IntSort(), IntSort(), IntSort())
-		return lsh_fun(l, r)
+    def _lsh(self, l, r, solver):
+        lsh_fun = Function('int_lsh', IntSort(), IntSort(), IntSort())
+        return lsh_fun(l, r)
 
-	def _rsh(self, l, r, solver):
-		rsh_fun = Function('int_rsh', IntSort(), IntSort(), IntSort())
-		return rsh_fun(l, r)
+    def _rsh(self, l, r, solver):
+        rsh_fun = Function('int_rsh', IntSort(), IntSort(), IntSort())
+        return rsh_fun(l, r)
 
-	def _xor(self, l, r, solver):
-		xor_fun = Function('int_xor', IntSort(), IntSort(), IntSort())
-		return xor_fun(l, r)
+    def _xor(self, l, r, solver):
+        xor_fun = Function('int_xor', IntSort(), IntSort(), IntSort())
+        return xor_fun(l, r)
 
-	def _or(self, l, r, solver):
-		or_fun = Function('int_or', IntSort(), IntSort(), IntSort())
-		return or_fun(l, r)
+    def _or(self, l, r, solver):
+        or_fun = Function('int_or', IntSort(), IntSort(), IntSort())
+        return or_fun(l, r)
 
-	def _and(self, l, r, solver):
-		and_fun = Function('int_and', IntSort(), IntSort(), IntSort())
-		return and_fun(l, r)
+    def _and(self, l, r, solver):
+        and_fun = Function('int_and', IntSort(), IntSort(), IntSort())
+        return and_fun(l, r)

--- a/symbolic/z3_wrap.py
+++ b/symbolic/z3_wrap.py
@@ -1,7 +1,5 @@
 # Copyright: see copyright.txt
 
-import sys
-import ast
 import logging
 
 from z3 import *
@@ -10,130 +8,133 @@ from .z3_expr.bitvector import Z3BitVector
 
 log = logging.getLogger("se.z3")
 
+
 class Z3Wrapper(object):
-	def __init__(self):
-		self.N = 32
-		self.asserts = None
-		self.query = None
-		self.use_lia = True
-		self.z3_expr = None
+    def __init__(self):
+        self.N = 32
+        self.asserts = None
+        self.query = None
+        self.solver = None
+        self.use_lia = True
+        self.z3_expr = None
 
-	def findCounterexample(self, asserts, query):
-		"""Tries to find a counterexample to the query while
-	  	 asserts remains valid."""
-		self.solver = Solver()
-		self.query = query
-		self.asserts = self._coneOfInfluence(asserts,query)
-		res = self._findModel()
-		log.debug("Query -- %s" % self.query)
-		log.debug("Asserts -- %s" % asserts)
-		log.debug("Cone -- %s" % self.asserts)
-		log.debug("Result -- %s" % res)
-		return res
+    def findCounterexample(self, asserts, query):
+        """Tries to find a counterexample to the query while
+           asserts remains valid."""
+        self.solver = Solver()
+        self.query = query
+        self.asserts = self._coneOfInfluence(asserts, query)
+        res = self._findModel()
+        log.debug("Query -- %s" % self.query)
+        log.debug("Asserts -- %s" % asserts)
+        log.debug("Cone -- %s" % self.asserts)
+        log.debug("Result -- %s" % res)
+        return res
 
-	# private
+    # private
 
-	# this is very inefficient
-	def _coneOfInfluence(self,asserts,query):
-		cone = []
-		cone_vars = set(query.getVars())
-		ws = [ a for a in asserts if len(set(a.getVars()) & cone_vars) > 0 ]
-		remaining = [ a for a in asserts if a not in ws ]
-		while len(ws) > 0:
-			a = ws.pop()
-			a_vars = set(a.getVars())
-			cone_vars = cone_vars.union(a_vars)
-			cone.append(a)
-			new_ws = [ a for a in remaining if len(set(a.getVars()) & cone_vars) > 0 ]
-			remaining = [ a for a in remaining if a not in new_ws ]
-			ws = ws + new_ws
-		return cone
+    # this is very inefficient
+    def _coneOfInfluence(self, asserts, query):
+        cone = []
+        cone_vars = set(query.getVars())
+        ws = [a for a in asserts if len(set(a.getVars()) & cone_vars) > 0]
+        remaining = [a for a in asserts if a not in ws]
+        while len(ws) > 0:
+            a = ws.pop()
+            a_vars = set(a.getVars())
+            cone_vars = cone_vars.union(a_vars)
+            cone.append(a)
+            new_ws = [a for a in remaining if len(set(a.getVars()) & cone_vars) > 0]
+            remaining = [a for a in remaining if a not in new_ws]
+            ws = ws + new_ws
+        return cone
 
-	def _findModel(self):
-		# Try QF_LIA first (as it may fairly easily recognize unsat instances)
-		if self.use_lia:
-			self.solver.push()
-			self.z3_expr = Z3Integer()
-			self.z3_expr.toZ3(self.solver,self.asserts,self.query)
-			res = self.solver.check()
-			#print(self.solver.assertions)
-			self.solver.pop()
-			if res == unsat:
-				return None
+    def _findModel(self):
+        # Try QF_LIA first (as it may fairly easily recognize unsat instances)
+        if self.use_lia:
+            self.solver.push()
+            self.z3_expr = Z3Integer()
+            self.z3_expr.toZ3(self.solver, self.asserts, self.query)
+            res = self.solver.check()
+            # print(self.solver.assertions)
+            self.solver.pop()
+            if res == unsat:
+                return None
 
-		# now, go for SAT with bounds
-		self.N = 32
-		self.bound = (1 << 4) - 1
-		while self.N <= 64:
-			self.solver.push()
-			(ret,mismatch) = self._findModel2()
-			if (not mismatch):
-				break
-			self.solver.pop()
-			self.N = self.N+8
-			if self.N <= 64: print("expanded bit width to "+str(self.N)) 
-		#print("Assertions")
-		#print(self.solver.assertions())
-		if ret == unsat:
-			res = None
-		elif ret == unknown:
-			res = None
-		elif not mismatch:
-			res = self._getModel()
-		else:
-			res = None
-		if self.N<=64: self.solver.pop()
-		return res
+        # now, go for SAT with bounds
+        self.N = 32
+        self.bound = (1 << 4) - 1
+        while self.N <= 64:
+            self.solver.push()
+            (ret, mismatch) = self._findModel2()
+            if not mismatch:
+                break
+            self.solver.pop()
+            self.N += 8
+            if self.N <= 64:
+                print("expanded bit width to " + str(self.N))
+        # print("Assertions")
+        # print(self.solver.assertions())
+        if ret == unsat:
+            res = None
+        elif ret == unknown:
+            res = None
+        elif not mismatch:
+            res = self._getModel()
+        else:
+            res = None
+        if self.N <= 64:
+            self.solver.pop()
+        return res
 
-	def _setAssertsQuery(self):
-		self.z3_expr = Z3BitVector(self.N)
-		self.z3_expr.toZ3(self.solver,self.asserts,self.query)
+    def _setAssertsQuery(self):
+        self.z3_expr = Z3BitVector(self.N)
+        self.z3_expr.toZ3(self.solver, self.asserts, self.query)
 
-	def _findModel2(self):
-		self._setAssertsQuery()
-		int_vars = self.z3_expr.getIntVars()
-		res = unsat
-		while res == unsat and self.bound <= (1 << (self.N-1))-1:
-			self.solver.push()
-			constraints = self._boundIntegers(int_vars,self.bound)
-			self.solver.assert_exprs(constraints)
-			res = self.solver.check()
-			if res == unsat:
-				self.bound = (self.bound << 1)+1
-				self.solver.pop()
-		if res == sat:
-			# Does concolic agree with Z3? If not, it may be due to overflow
-			model = self._getModel()
-			#print("Match?")
-			#print(self.solver.assertions)
-			self.solver.pop()
-			mismatch = False
-			for a in self.asserts:
-				eval = self.z3_expr.predToZ3(a,self.solver,model)
-				if (not eval):
-					mismatch = True
-					break
-			if (not mismatch):
-				mismatch = not (not self.z3_expr.predToZ3(self.query,self.solver,model))
-			#print(mismatch)
-			return (res,mismatch)
-		elif res == unknown:
-			self.solver.pop()
-		return (res,False)
+    def _findModel2(self):
+        self._setAssertsQuery()
+        int_vars = self.z3_expr.getIntVars()
+        res = unsat
+        while res == unsat and self.bound <= (1 << (self.N - 1)) - 1:
+            self.solver.push()
+            constraints = self._boundIntegers(int_vars, self.bound)
+            self.solver.assert_exprs(constraints)
+            res = self.solver.check()
+            if res == unsat:
+                self.bound = (self.bound << 1) + 1
+                self.solver.pop()
+        if res == sat:
+            # Does concolic agree with Z3? If not, it may be due to overflow
+            model = self._getModel()
+            # print("Match?")
+            # print(self.solver.assertions)
+            self.solver.pop()
+            mismatch = False
+            for a in self.asserts:
+                evaluation = self.z3_expr.predToZ3(a, self.solver, model)
+                if not evaluation:
+                    mismatch = True
+                    break
+            if not mismatch:
+                mismatch = not (not self.z3_expr.predToZ3(self.query, self.solver, model))
+            # print(mismatch)
+            return res, mismatch
+        elif res == unknown:
+            self.solver.pop()
+        return res, False
 
-	def _getModel(self):
-		res = {}
-		model = self.solver.model()
-		for name in self.z3_expr.z3_vars.keys():
-			try:
-				ce = model.eval(self.z3_expr.z3_vars[name])
-				res[name] = ce.as_signed_long()
-			except:
-				pass
-		return res
-	
-	def _boundIntegers(self,vars,val):
-		bval = BitVecVal(val,self.N,self.solver.ctx)
-		bval_neg = BitVecVal(-val-1,self.N,self.solver.ctx)
-		return And([ v <= bval for v in vars]+[ bval_neg <= v for v in vars])
+    def _getModel(self):
+        res = {}
+        model = self.solver.model()
+        for name in self.z3_expr.z3_vars.keys():
+            try:
+                ce = model.eval(self.z3_expr.z3_vars[name])
+                res[name] = ce.as_signed_long()
+            except:
+                pass
+        return res
 
+    def _boundIntegers(self, variables, val):
+        bval = BitVecVal(val, self.N, self.solver.ctx)
+        bval_neg = BitVecVal(-val - 1, self.N, self.solver.ctx)
+        return And([v <= bval for v in variables] + [bval_neg <= v for v in variables])

--- a/utils.py
+++ b/utils.py
@@ -3,12 +3,14 @@
 import sys
 import traceback
 
+
 def traceback():
-	stack = traceback.format_stack()
-	rest = stack[:-2]
-	return "\n"+"".join(rest)
+    stack = traceback.format_stack()
+    rest = stack[:-2]
+    return "\n" + "".join(rest)
+
 
 def crash(msg):
-	#stack = _traceback()
-	print(msg)
-	sys.exit(-1)
+    # stack = _traceback()
+    print(msg)
+    sys.exit(-1)


### PR DESCRIPTION
I cleaned up the codebase to be closer to the [Python Style Guide](https://www.python.org/dev/peps/pep-0008/). The majority of the changes deal with indents with spaces, `None` comparisons using the `is` operator, and redundant parentheses. Some variable names were changed to avoid overloading built-in operators. I tested the refactoring on the project's test suite on Windows and Linux. If these cosmetic modifications do not align with the desired coding style of the project, please let me know so I can get the string code to conform!